### PR TITLE
Handle variations of Font size attribute values

### DIFF
--- a/example/example-node.js
+++ b/example/example-node.js
@@ -275,6 +275,66 @@ const htmlString = `<!DOCTYPE html>
             </li>
         </ul>
 
+        <!-- Test cases for PR #15: Font size CSS keywords -->
+        <h3>Font Size CSS Keywords Test (PR #15)</h3>
+
+        <p>Testing absolute font-size keywords:</p>
+        <p style="font-size: xx-small;">This text is xx-small (9px equivalent)</p>
+        <p style="font-size: x-small;">This text is x-small (10px equivalent)</p>
+        <p style="font-size: small;">This text is small (13px equivalent)</p>
+        <p style="font-size: medium;">This text is medium (16px equivalent - default)</p>
+        <p style="font-size: large;">This text is large (18px equivalent)</p>
+        <p style="font-size: x-large;">This text is x-large (24px equivalent)</p>
+        <p style="font-size: xx-large;">This text is xx-large (32px equivalent)</p>
+        <p style="font-size: xxx-large;">This text is xxx-large (48px equivalent)</p>
+
+        <p>Testing relative font-size keywords:</p>
+        <div style="font-size: 16px;">
+            <p>Parent has 16px font size</p>
+            <p style="font-size: smaller;">This text is 'smaller' (5/6 of parent = ~13px)</p>
+            <p style="font-size: larger;">This text is 'larger' (1.2x of parent = ~19px)</p>
+        </div>
+
+        <p>Testing nested relative keywords:</p>
+        <div style="font-size: 20px;">
+            <span>Base: 20px</span>
+            <div style="font-size: larger;">
+                <span>First larger: ~24px</span>
+                <div style="font-size: smaller;">
+                    <span>Then smaller: ~20px</span>
+                </div>
+            </div>
+        </div>
+
+        <p>Testing mixed units and keywords:</p>
+        <ul>
+            <li style="font-size: small;">Small text in list item</li>
+            <li style="font-size: 14pt;">14pt text in list item</li>
+            <li style="font-size: large;">Large text in list item</li>
+            <li style="font-size: 150%;">150% text in list item</li>
+            <li style="font-size: xx-large;">XX-Large text in list item</li>
+        </ul>
+
+        <p>Testing keywords in complex nested structures:</p>
+        <table border="1">
+            <tr>
+                <td style="font-size: x-small;">X-Small in table cell</td>
+                <td style="font-size: medium;">Medium in table cell</td>
+                <td style="font-size: x-large;">X-Large in table cell</td>
+            </tr>
+            <tr>
+                <td style="font-size: smaller;">Smaller in table cell</td>
+                <td>Default size in table cell</td>
+                <td style="font-size: larger;">Larger in table cell</td>
+            </tr>
+        </table>
+
+        <p>Testing edge cases:</p>
+        <p style="font-size: invalid-keyword;">Invalid keyword should fallback to default</p>
+        <p style="font-size: ;">Empty font-size should use default</p>
+        <p style="font-size: 0;">Zero font-size edge case</p>
+        <span style="font-size: smaller;">Relative size without explicit parent</span>
+
         <p>Different borders</p>
         <table
             style="border-collapse: collapse; border-left:1px solid black; border-right: 2px solid brown; border-top: 2px solid yellow; border-bottom: 4px solid orange">

--- a/src/constants.js
+++ b/src/constants.js
@@ -123,6 +123,22 @@ const colorlessColors = ['transparent', 'auto'];
 const verticalAlignValues = ['top', 'middle', 'bottom'];
 const defaultPercentageMarginValue = 0;
 
+const absoluteFontSizes = {
+  'xx-small': '9px',
+  'x-small': '10px',
+  'small': '13px',
+  'medium': '16px',
+  'large': '18px',
+  'x-large': '24px',
+  'xx-large': '32px',
+  'xxx-large': '48px',
+};
+
+const relativeFontSizeFactors = {
+  smaller: 5 / 6,
+  larger: 1.2,
+};
+
 export {
   defaultDocumentOptions,
   defaultTableBorderOptions,
@@ -155,4 +171,6 @@ export {
   defaultDirection,
   defaultPercentageMarginValue,
   defaultTableBorderAttributeOptions,
+  absoluteFontSizes,
+  relativeFontSizeFactors,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -123,6 +123,10 @@ const colorlessColors = ['transparent', 'auto'];
 const verticalAlignValues = ['top', 'middle', 'bottom'];
 const defaultPercentageMarginValue = 0;
 
+/**
+ * CSS absolute font-size keyword mappings to pixel values
+ * Based on CSS specification: https://developer.mozilla.org/en-US/docs/Web/CSS/font-size
+ */
 const absoluteFontSizes = {
   'xx-small': '9px',
   'x-small': '10px',
@@ -134,6 +138,11 @@ const absoluteFontSizes = {
   'xxx-large': '48px',
 };
 
+/**
+ * Scaling factors for relative font-size keywords
+ * - smaller: 5/6 of parent font size
+ * - larger: 1.2x of parent font size
+ */
 const relativeFontSizeFactors = {
   smaller: 5 / 6,
   larger: 1.2,

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -365,6 +365,24 @@ const fixupLineHeight = (lineHeight, fontSize) => {
 
 // eslint-disable-next-line consistent-return
 const fixupFontSize = (fontSizeString, docxDocumentInstance) => {
+  if (fontSizeString === 'xx-small') {
+    fontSizeString = '9px';
+  } else if (fontSizeString === 'x-small') {
+    fontSizeString = '10px';
+  } else if (fontSizeString === 'small') {
+    fontSizeString = '13px';
+  } else if (fontSizeString === 'medium') {
+    fontSizeString = '16px';
+  } else if (fontSizeString === 'large') {
+    fontSizeString = '18px';
+  } else if (fontSizeString === 'x-large') {
+    fontSizeString = '24px';
+  } else if (fontSizeString === 'xx-large') {
+    fontSizeString = '32px';
+  } else if (fontSizeString === 'xxx-large') {
+    fontSizeString = '48px';
+  }
+
   if (pointRegex.test(fontSizeString)) {
     const matchedParts = fontSizeString.match(pointRegex);
     // convert point to half point
@@ -385,6 +403,7 @@ const fixupFontSize = (fontSizeString, docxDocumentInstance) => {
     return (matchedParts[1] * docxDocumentInstance.fontSize) / 100;
   }
 };
+
 
 // eslint-disable-next-line consistent-return
 const fixupRowHeight = (rowHeightString, parentHeight = 0) => {

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -365,6 +365,8 @@ const fixupLineHeight = (lineHeight, fontSize) => {
 
 // eslint-disable-next-line consistent-return
 const fixupFontSize = (fontSizeString, docxDocumentInstance) => {
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/font-size
+  // Checked manually which size generates what px value and found the below
   if (fontSizeString === 'xx-small') {
     fontSizeString = '9px';
   } else if (fontSizeString === 'x-small') {
@@ -381,6 +383,18 @@ const fixupFontSize = (fontSizeString, docxDocumentInstance) => {
     fontSizeString = '32px';
   } else if (fontSizeString === 'xxx-large') {
     fontSizeString = '48px';
+  }
+
+  if (fontSizeString === 'smaller') {
+    // for this case, font-size becomes 5/6 of the parent font size.
+    // since we dont have access to immediate parent size
+    // we will use the default font size given to us
+    return Math.floor((5 * docxDocumentInstance.fontSize) / 6);
+  } else if (fontSizeString === 'larger') {
+    // for this case, font-size inceases by 20% of the parent font size.
+    // since we dont have access to immediate parent size
+    // we will use the default font size given to us
+    return Math.floor(docxDocumentInstance.fontSize * 1.2);
   }
 
   if (pointRegex.test(fontSizeString)) {
@@ -403,7 +417,6 @@ const fixupFontSize = (fontSizeString, docxDocumentInstance) => {
     return (matchedParts[1] * docxDocumentInstance.fontSize) / 100;
   }
 };
-
 
 // eslint-disable-next-line consistent-return
 const fixupRowHeight = (rowHeightString, parentHeight = 0) => {

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -368,22 +368,13 @@ const fixupLineHeight = (lineHeight, fontSize) => {
 
 // eslint-disable-next-line consistent-return
 const fixupFontSize = (fontSizeString, docxDocumentInstance) => {
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/font-size
-  
-  // Handle relative font size keywords first
-  if (fontSizeString === 'smaller') {
-    // for this case, font-size becomes 5/6 of the parent font size.
+
+  if (["smaller", "larger"].includes(fontSizeString)) {
     // since we dont have access to immediate parent size
     // we will use the default font size given to us
-    return Math.floor(relativeFontSizeFactors.smaller * docxDocumentInstance.fontSize);
-  } else if (fontSizeString === 'larger') {
-    // for this case, font-size increases by 20% of the parent font size.
-    // since we dont have access to immediate parent size
-    // we will use the default font size given to us
-    return Math.floor(docxDocumentInstance.fontSize * relativeFontSizeFactors.larger);
+    return Math.floor(relativeFontSizeFactors[fontSizeString] * docxDocumentInstance.fontSize);
   }
 
-  // Handle absolute font size keywords
   if (absoluteFontSizes[fontSizeString]) {
     fontSizeString = absoluteFontSizes[fontSizeString];
   }
@@ -1092,26 +1083,26 @@ const buildRunOrHyperLink = async (vNode, attributes, docxDocumentInstance) => {
 
     if (vNode.children) {
       for (let idx = 0; idx < vNode.children.length; idx++) {
-      const childVNode = vNode.children[idx];
-      const modifiedAttributes =
-        isVNode(childVNode) && childVNode.tagName === 'img'
-          ? { ...attributes, type: 'picture', description: childVNode.properties.alt } : { ...attributes };
-      modifiedAttributes.hyperlink = true;
+        const childVNode = vNode.children[idx];
+        const modifiedAttributes =
+          isVNode(childVNode) && childVNode.tagName === 'img'
+            ? { ...attributes, type: 'picture', description: childVNode.properties.alt } : { ...attributes };
+        modifiedAttributes.hyperlink = true;
 
-      const runFragments = await buildRunOrRuns(
-        childVNode,
-        modifiedAttributes,
-        docxDocumentInstance
-      );
-      if (Array.isArray(runFragments)) {
-        for (let index = 0; index < runFragments.length; index++) {
-          const runFragment = runFragments[index];
+        const runFragments = await buildRunOrRuns(
+          childVNode,
+          modifiedAttributes,
+          docxDocumentInstance
+        );
+        if (Array.isArray(runFragments)) {
+          for (let index = 0; index < runFragments.length; index++) {
+            const runFragment = runFragments[index];
 
-          hyperlinkFragment.import(runFragment);
+            hyperlinkFragment.import(runFragment);
+          }
+        } else {
+          hyperlinkFragment.import(runFragments);
         }
-      } else {
-        hyperlinkFragment.import(runFragments);
-      }
       }
     }
 
@@ -1338,7 +1329,7 @@ const computeImageDimensions = (vNode, attributes) => {
   const maximumWidthInEMU = TWIPToEMU(maximumWidth);
   let originalWidthInEMU = pixelToEMU(originalWidth);
   let originalHeightInEMU = pixelToEMU(originalHeight);
-  
+
   if (originalWidthInEMU > maximumWidthInEMU) {
     originalWidthInEMU = maximumWidthInEMU;
     originalHeightInEMU = Math.round(originalWidthInEMU / aspectRatio);
@@ -1408,7 +1399,7 @@ const computeImageDimensions = (vNode, attributes) => {
     } else if (modifiedHeight && !modifiedWidth) {
       modifiedWidth = Math.round(modifiedHeight * aspectRatio);
     }
-    
+
     // Fallback for images with non-dimensional CSS styles
     // HTML like <img style="font-family: Poppins;" src="..."> creates a style object
     // but contains no width/height properties. The function enters this if block but never
@@ -1430,7 +1421,7 @@ const computeImageDimensions = (vNode, attributes) => {
     modifiedWidth = originalWidthInEMU;
     modifiedHeight = originalHeightInEMU;
   }
-  
+
   // eslint-disable-next-line no-param-reassign
   attributes.width = modifiedWidth;
   // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
Fixes #122

This PR adds support for CSS font-size keyword values that were previously unsupported.

## Changes

- Added mapping for absolute size keywords (`xx-small` through `xxx-large`) to pixel equivalents
- Implemented relative size keyword handling (`smaller`, `larger`) based on document default font size
- Added proper handling in `fixupFontSize` function

## Testing

Manually verified pixel mappings against browser behavior for consistency.

Resolves the issue where HTML containing CSS font-size keywords would not be properly converted to DOCX format.