### PR TITLE
Feature/text-decoration property

### DIFF
--- a/example/example-node.js
+++ b/example/example-node.js
@@ -1428,6 +1428,12 @@ const htmlString = `<!DOCTYPE html>
                 <p style="text-decoration-color: orange">
                     This line has orange underline style in p tag.
                 </p>
+                <p style="text-decoration:underline orange">
+                    <span style="text-decoration: line-through red">
+                        Hey, here I lie within <strong style="text-decoration: overline;">the strong tag</strong>
+                        and now
+                    </span> oustide every tag
+                </p>
             </p>
         </div>
 

--- a/example/example-node.js
+++ b/example/example-node.js
@@ -1407,20 +1407,26 @@ const htmlString = `<!DOCTYPE html>
         <div>
             <p>
                 Here we check for text-decoration properties:
-                <p style="text-decoration: underline">
+                <p style="text-decoration: dashed underline red">
                     This is an underline text.
                 </p>
-                <strong style="text-decoration: overline">
+                <strong style="text-decoration: wavy overline lime">
                     This is an overline text in strong tag.
                 </strong>
-                <span style="text-decoration: line-through">
+                <span style="text-decoration: line-through red">
                     This is line-through text in span tag.
                 </span>
-                <p style="text-decoration: underline overline line-through">
+                <p style="text-decoration: underline overline line-through blue">
                     This line has underline, overline and line-through styles in p tag.
                 </p>
-                <p style="text-decoration: ">
-                    This line has empty text-decoration.
+                <p style="text-decoration-style: dotted">
+                    This line has dotted underline styles in p tag.
+                </p>
+                <p style="text-decoration-line: line-through">
+                    This line has line-through styles in p tag.
+                </p>
+                <p style="text-decoration-color: orange">
+                    This line has orange underline style in p tag.
                 </p>
             </p>
         </div>

--- a/example/example-node.js
+++ b/example/example-node.js
@@ -1404,6 +1404,27 @@ const htmlString = `<!DOCTYPE html>
         </strong>
         </p>
 
+        <div>
+            <p>
+                Here we check for text-decoration properties:
+                <p style="text-decoration: underline">
+                    This is an underline text.
+                </p>
+                <strong style="text-decoration: overline">
+                    This is an overline text in strong tag.
+                </strong>
+                <span style="text-decoration: line-through">
+                    This is line-through text in span tag.
+                </span>
+                <p style="text-decoration: underline overline line-through">
+                    This line has underline, overline and line-through styles in p tag.
+                </p>
+                <p style="text-decoration: ">
+                    This line has empty text-decoration.
+                </p>
+            </p>
+        </div>
+
         <p>Some tr styles cases</p>
         <p>Color property only passed to tr</p>
         <div align="left">

--- a/example/example.js
+++ b/example/example.js
@@ -1404,6 +1404,33 @@ const htmlString = `<!DOCTYPE html>
         </strong>
         </p>
 
+        <div>
+            <p>
+                Here we check for text-decoration properties:
+                <p style="text-decoration: dashed underline red">
+                    This is an underline text.
+                </p>
+                <strong style="text-decoration: wavy overline lime">
+                    This is an overline text in strong tag.
+                </strong>
+                <span style="text-decoration: line-through red">
+                    This is line-through text in span tag.
+                </span>
+                <p style="text-decoration: underline overline line-through blue">
+                    This line has underline, overline and line-through styles in p tag.
+                </p>
+                <p style="text-decoration-style: dotted">
+                    This line has dotted underline styles in p tag.
+                </p>
+                <p style="text-decoration-line: line-through">
+                    This line has line-through styles in p tag.
+                </p>
+                <p style="text-decoration-color: orange">
+                    This line has orange underline style in p tag.
+                </p>
+            </p>
+        </div>
+
         <p>Some tr styles cases</p>
         <p>Color property only passed to tr</p>
         <div align="left">

--- a/example/example.js
+++ b/example/example.js
@@ -1428,6 +1428,12 @@ const htmlString = `<!DOCTYPE html>
                 <p style="text-decoration-color: orange">
                     This line has orange underline style in p tag.
                 </p>
+                <p style="text-decoration:underline orange">
+                    <span style="text-decoration: line-through red">
+                        Hey, here I lie within <strong style="text-decoration: overline;">the strong tag</strong>
+                        and now
+                    </span> oustide every tag
+                </p>
             </p>
         </div>
 

--- a/example/react-example/src/App.js
+++ b/example/react-example/src/App.js
@@ -1401,6 +1401,33 @@ const htmlString = `<!DOCTYPE html>
         </strong>
         </p>
 
+        <div>
+            <p>
+                Here we check for text-decoration properties:
+                <p style="text-decoration: dashed underline red">
+                    This is an underline text.
+                </p>
+                <strong style="text-decoration: wavy overline lime">
+                    This is an overline text in strong tag.
+                </strong>
+                <span style="text-decoration: line-through red">
+                    This is line-through text in span tag.
+                </span>
+                <p style="text-decoration: underline overline line-through blue">
+                    This line has underline, overline and line-through styles in p tag.
+                </p>
+                <p style="text-decoration-style: dotted">
+                    This line has dotted underline styles in p tag.
+                </p>
+                <p style="text-decoration-line: line-through">
+                    This line has line-through styles in p tag.
+                </p>
+                <p style="text-decoration-color: orange">
+                    This line has orange underline style in p tag.
+                </p>
+            </p>
+        </div>
+
         <p>Some tr styles cases</p>
         <p>Color property only passed to tr</p>
         <div align="left">

--- a/example/react-example/src/App.js
+++ b/example/react-example/src/App.js
@@ -1425,6 +1425,12 @@ const htmlString = `<!DOCTYPE html>
                 <p style="text-decoration-color: orange">
                     This line has orange underline style in p tag.
                 </p>
+                <p style="text-decoration:underline orange">
+                    <span style="text-decoration: line-through red">
+                        Hey, here I lie within <strong style="text-decoration: overline;">the strong tag</strong>
+                        and now
+                    </span> oustide every tag
+                </p>
             </p>
         </div>
 

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax */
 /* eslint-disable no-await-in-loop */
 /* eslint-disable radix */
 /* eslint-disable no-param-reassign */
@@ -279,7 +278,6 @@ const buildTextElement = (text) =>
     .up();
 
 const buildTextDecoration = (value) => {
-  console.log(value);
   if (value.line === 'underline') {
     return fragment({ namespaceAlias: { w: namespaces.w } })
       .ele('@w', 'u')
@@ -304,6 +302,7 @@ const buildTextDecoration = (value) => {
     .up();
 };
 
+// maps html text-decoration-style attribute values to ooxml values
 const fixupTextDecorationStyle = (style) => {
   if (['dotted', 'double'].includes(style)) {
     return style;
@@ -316,6 +315,7 @@ const fixupTextDecorationStyle = (style) => {
   return map[style];
 };
 
+// maps html text-decoration-line attribute values to ooxml values
 const fixupTextDecorationLine = (line) => {
   if (['overline', 'blink'].includes(line)) {
     return 'none';
@@ -631,6 +631,7 @@ const modifiedStyleAttributesBuilder = (docxDocumentInstance, vNode, attributes,
         const value = {};
 
         // eslint-disable-next-line no-loop-func
+        // mapping each value to specific property of text-decoration
         valueParts.forEach((valuePart) => {
           if (isColorCode(valuePart)) {
             value.color = fixupColorCode(valuePart);


### PR DESCRIPTION
Added support for text-decoration property.

Keep note of the following points:
- only `underline` and `line-through` are supported by OOXML.
- properties like `overline` are not supported, hence skipped.
- empty `text-decoration` fields are also handled.