### PR TITLE
Feature/text-shadow

### DIFF
--- a/example/example-node.js
+++ b/example/example-node.js
@@ -1437,6 +1437,13 @@ const htmlString = `<!DOCTYPE html>
             </p>
         </div>
 
+        <div>
+            <span style="text-shadow: 1px 1px 2px grey;">Add new domain</span> to Google Workspace
+            <p style="text-shadow: 1px 1px 2px grey;">This text has shadow.<strong> And this has shadow with strong tag.</strong> </p>
+            <p style="text-shadow:">This text has empty shadow property.</p>
+            <p style="text-shadow: none">This text has none shadow property.</p>
+        </div>
+
         <p>Some tr styles cases</p>
         <p>Color property only passed to tr</p>
         <div align="left">

--- a/example/example.js
+++ b/example/example.js
@@ -1437,6 +1437,13 @@ const htmlString = `<!DOCTYPE html>
             </p>
         </div>
 
+        <div>
+            <span style="text-shadow: 1px 1px 2px grey;">Add new domain</span> to Google Workspace
+            <p style="text-shadow: 1px 1px 2px grey;">This text has shadow.<strong> And this has shadow with strong tag.</strong> </p>
+            <p style="text-shadow:">This text has empty shadow property.</p>
+            <p style="text-shadow: none">This text has none shadow property.</p>
+        </div>
+
         <p>Some tr styles cases</p>
         <p>Color property only passed to tr</p>
         <div align="left">

--- a/example/react-example/src/App.js
+++ b/example/react-example/src/App.js
@@ -1434,6 +1434,13 @@ const htmlString = `<!DOCTYPE html>
             </p>
         </div>
 
+        <div>
+            <span style="text-shadow: 1px 1px 2px grey;">Add new domain</span> to Google Workspace
+            <p style="text-shadow: 1px 1px 2px grey;">This text has shadow.<strong> And this has shadow with strong tag.</strong> </p>
+            <p style="text-shadow:">This text has empty shadow property.</p>
+            <p style="text-shadow: none">This text has none shadow property.</p>
+        </div>
+
         <p>Some tr styles cases</p>
         <p>Color property only passed to tr</p>
         <div align="left">

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -322,6 +322,11 @@ const fixupTextDecorationLine = (line) => {
   }
   return line;
 };
+const buildTextShadow = () =>
+  fragment({ namespaceAlias: { w: namespaces.w } })
+    .ele('@w', 'shadow')
+    .att('@w', 'val', true)
+    .up();
 
 // eslint-disable-next-line consistent-return
 const fixupLineHeight = (lineHeight, fontSize) => {
@@ -667,7 +672,9 @@ const modifiedStyleAttributesBuilder = (docxDocumentInstance, vNode, attributes,
           line: 'underline',
         };
       } else if (vNodeStyleKey === 'text-shadow') {
-        modifiedAttributes.textShadow = vNodeStyleValue;
+        if (vNodeStyleValue.trim() !== '' && vNodeStyleValue !== 'none') {
+          modifiedAttributes.textShadow = vNodeStyleValue;
+        }
       }
     }
   }
@@ -729,6 +736,8 @@ const buildFormatting = (htmlTag, options) => {
       return buildRunStyleFragment('Hyperlink');
     case 'textDecoration':
       return buildTextDecoration(options && options.textDecoration ? options.textDecoration : {});
+    case 'textShadow':
+      return buildTextShadow();
   }
 
   return null;
@@ -749,6 +758,10 @@ const buildRunProperties = (attributes) => {
 
       if (key === 'textDecoration') {
         options.textDecoration = attributes[key];
+      }
+      
+      if (key === 'textShadow') {
+        options.textShadow = attributes[key];
       }
 
       const formattingFragment = buildFormatting(key, options);


### PR DESCRIPTION
### Added handler for text-shadow property

OOXML has only support for enabling/disabling `text-shadow` property(i.e. it is a toggle property). So the contents of text-shadow property are not parsed if present.

- If `text-shadow: <empty>` or `text-shadow: none`, then shadow is not toggled.
- Otherwise, shadow is toggled.