### PR TITLE
Add missing 'Normal' style

### DIFF
--- a/src/schemas/styles.js
+++ b/src/schemas/styles.js
@@ -25,6 +25,9 @@ const generateStylesXML = (
 		</w:pPr>
 	  </w:pPrDefault>
 	</w:docDefaults>
+	<w:style w:type="paragraph" w:styleId="Normal" w:default="1">
+	  <w:name w:val="normal" />
+	</w:style>
 	<w:style w:type="character" w:styleId="Hyperlink">
 	  <w:name w:val="Hyperlink" />
 	  <w:rPr>


### PR DESCRIPTION
This fixes https://github.com/privateOmega/html-to-docx/issues/180, where Heading styles "bleeds" over to normal text in paragraphs below, when viewed in macOS Pages.

The problem seems to be that all other defined styles are based on "Normal" (see `w:basedOn` in the same file), which didn't exist. Other docx viewers seems to handle this issue, but Pages renders it incorrectly.