### PR TITLE
feat: support <a> tags nested in <span>

### DIFF
--- a/example/example-node.js
+++ b/example/example-node.js
@@ -96,6 +96,17 @@ const htmlString = `<!DOCTYPE html>
                     </strong>
                 </a>
             </li>
+            <li>
+                <span>
+                    Black
+                    <a href="https://en.wikipedia.org/wiki/Coffee">
+                        Strong
+                        <strong>
+                            <u>Coffee</u>
+                        </strong>
+                    </a>
+                </span>
+            </li>
             <li>Tea
                 <ol>
                     <li>Black tea

--- a/example/example.js
+++ b/example/example.js
@@ -96,6 +96,17 @@ const htmlString = `<!DOCTYPE html>
                     </strong>
                 </a>
             </li>
+            <li>
+                <span>
+                    Black
+                    <a href="https://en.wikipedia.org/wiki/Coffee">
+                        Strong
+                        <strong>
+                            <u>Coffee</u>
+                        </strong>
+                    </a>
+                </span>
+            </li>
             <li>Tea
                 <ol>
                     <li>Black tea

--- a/example/react-example/src/App.js
+++ b/example/react-example/src/App.js
@@ -93,6 +93,17 @@ const htmlString = `<!DOCTYPE html>
                     </strong>
                 </a>
             </li>
+            <li>
+                <span>
+                    Black
+                    <a href="https://en.wikipedia.org/wiki/Coffee">
+                        Strong
+                        <strong>
+                            <u>Coffee</u>
+                        </strong>
+                    </a>
+                </span>
+            </li>
             <li>Tea
                 <ol>
                     <li>Black tea

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -1039,7 +1039,7 @@ const buildRunOrRuns = async (vNode, attributes, docxDocumentInstance) => {
         attributes
       );
 
-      const tempRunFragments = await buildRun(childVNode, isVNode(childVNode) && childVNode.tagName === 'img'
+      const tempRunFragments = await buildRunOrHyperLink(childVNode, isVNode(childVNode) && childVNode.tagName === 'img'
         ? { ...modifiedAttributes, type: 'picture', description: childVNode.properties.alt } : modifiedAttributes, docxDocumentInstance);
       runFragments = runFragments.concat(
         Array.isArray(tempRunFragments) ? tempRunFragments : [tempRunFragments]


### PR DESCRIPTION
Links nested in `<span>`'s are not picked up by `buildRunOrRuns` and are simply ignored.

For example,
`Here <span>is a <a href="#">link</a>`
becomes this in docx:
`Here is a`

This fixes it, but I'm not sure about the consequences of calling `buildRunOrHyperLink` from inside `buildRunOrRuns`.