### PR TITLE
RTL Support 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.24.2",
         "eslint-plugin-prettier": "^4.0.0",
-        "husky": "^7.0.0",
         "lint-staged": "^11.1.2",
         "prettier": "^2.4.1",
         "rollup": "^2.62.0",
@@ -3483,21 +3482,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/idb-wrapper": {
@@ -9552,12 +9536,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true
-    },
-    "husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
       "dev": true
     },
     "idb-wrapper": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@turbodocx/html-to-docx",
-  "version": "1.12.0",
+  "name": "html-to-docx-rtl",
+  "version": "1.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@turbodocx/html-to-docx",
+      "name": "html-to-docx-rtl",
       "version": "1.12.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-prettier": "^4.0.0",
-    "husky": "^7.0.0",
     "lint-staged": "^11.1.2",
     "prettier": "^2.4.1",
     "rollup": "^2.62.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@turbodocx/html-to-docx",
+  "name": "html-to-docx-rtl",
   "version": "1.12.0",
   "description": "HTML to DOCX converter",
   "keywords": [
@@ -45,8 +45,7 @@
     "lint": "eslint --fix .",
     "prettier:check": "prettier --check '**/*.{js}'",
     "validate": "run-s lint prettier:check",
-    "build": "rollup -c",
-    "prepare": "husky install"
+    "build": "rollup -c"
   },
   "repository": {
     "type": "git",

--- a/src/docx-document.js
+++ b/src/docx-document.js
@@ -116,6 +116,7 @@ class DocxDocument {
     this.htmlString = properties.htmlString;
     this.orientation = properties.orientation;
     this.pageSize = properties.pageSize || defaultDocumentOptions.pageSize;
+    this.isRTL = properties.isRTL || false;
 
     const isPortraitOrientation = this.orientation === defaultOrientation;
     const height = this.pageSize.height ? this.pageSize.height : landscapeHeight;
@@ -212,7 +213,7 @@ class DocxDocument {
   generateDocumentXML() {
     const documentXML = create(
       { encoding: 'UTF-8', standalone: true },
-      generateDocumentTemplate(this.width, this.height, this.orientation, this.margins)
+      generateDocumentTemplate(this.width, this.height, this.orientation, this.margins, this.isRTL)
     );
     documentXML.root().first().import(this.documentXML);
 

--- a/src/helpers/render-document-file.js
+++ b/src/helpers/render-document-file.js
@@ -78,6 +78,7 @@ export const buildImage = async (docxDocumentInstance, vNode, maximumWidth = nul
         maximumWidth: maximumWidth || docxDocumentInstance.availableDocumentSpace,
         originalWidth: imageProperties.width,
         originalHeight: imageProperties.height,
+        isRTL: docxDocumentInstance.isRTL, // Pass RTL flag
       },
       docxDocumentInstance
     );
@@ -110,6 +111,7 @@ export const buildList = async (vNode, docxDocumentInstance, xmlFragment) => {
         tempVNodeObject.node,
         {
           numbering: { levelId: tempVNodeObject.level, numberingId: tempVNodeObject.numberingId },
+          isRTL: docxDocumentInstance.isRTL,
         },
         docxDocumentInstance
       );
@@ -227,6 +229,7 @@ async function findXMLEquivalent(docxDocumentInstance, vNode, xmlFragment) {
         vNode,
         {
           paragraphStyle: `Heading${vNode.tagName[1]}`,
+          isRTL: docxDocumentInstance.isRTL,
         },
         docxDocumentInstance
       );
@@ -250,7 +253,13 @@ async function findXMLEquivalent(docxDocumentInstance, vNode, xmlFragment) {
     case 'blockquote':
     case 'code':
     case 'pre':
-      const paragraphFragment = await xmlBuilder.buildParagraph(vNode, {}, docxDocumentInstance);
+      const paragraphFragment = await xmlBuilder.buildParagraph(
+        vNode,
+        {
+          isRTL: docxDocumentInstance.isRTL, // Pass RTL flag
+        },
+        docxDocumentInstance
+      );
       xmlFragment.import(paragraphFragment);
       return;
     case 'figure':
@@ -264,13 +273,16 @@ async function findXMLEquivalent(docxDocumentInstance, vNode, xmlFragment) {
               {
                 maximumWidth: docxDocumentInstance.availableDocumentSpace,
                 rowCantSplit: docxDocumentInstance.tableRowCantSplit,
+                isRTL: docxDocumentInstance.isRTL,
               },
               docxDocumentInstance
             );
             xmlFragment.import(tableFragment);
             // Adding empty paragraph for space after table only if the option is enabled
             if (docxDocumentInstance.addSpacingAfterTable) {
-              const emptyParagraphFragment = await xmlBuilder.buildParagraph(null, {});
+              const emptyParagraphFragment = await xmlBuilder.buildParagraph(null, {
+                isRTL: docxDocumentInstance.isRTL,
+              });
               xmlFragment.import(emptyParagraphFragment);
             }
           } else if (childVNode.tagName === 'img') {
@@ -288,13 +300,16 @@ async function findXMLEquivalent(docxDocumentInstance, vNode, xmlFragment) {
         {
           maximumWidth: docxDocumentInstance.availableDocumentSpace,
           rowCantSplit: docxDocumentInstance.tableRowCantSplit,
+          isRTL: docxDocumentInstance.isRTL,
         },
         docxDocumentInstance
       );
       xmlFragment.import(tableFragment);
       // Adding empty paragraph for space after table only if the option is enabled
       if (docxDocumentInstance.addSpacingAfterTable) {
-        const emptyParagraphFragment = await xmlBuilder.buildParagraph(null, {});
+        const emptyParagraphFragment = await xmlBuilder.buildParagraph(null, {
+          isRTL: docxDocumentInstance.isRTL,
+        });
         xmlFragment.import(emptyParagraphFragment);
       }
       return;
@@ -309,7 +324,9 @@ async function findXMLEquivalent(docxDocumentInstance, vNode, xmlFragment) {
       }
       return;
     case 'br':
-      const linebreakFragment = await xmlBuilder.buildParagraph(null, {});
+      const linebreakFragment = await xmlBuilder.buildParagraph(null, {
+        isRTL: docxDocumentInstance.isRTL,
+      });
       xmlFragment.import(linebreakFragment);
       return;
     case 'head':
@@ -340,7 +357,13 @@ export async function convertVTreeToXML(docxDocumentInstance, vTree, xmlFragment
   } else if (isVNode(vTree)) {
     await findXMLEquivalent(docxDocumentInstance, vTree, xmlFragment);
   } else if (isVText(vTree)) {
-    const paragraphFragment = await xmlBuilder.buildParagraph(vTree, {}, docxDocumentInstance);
+    const paragraphFragment = await xmlBuilder.buildParagraph(
+      vTree,
+      {
+        isRTL: docxDocumentInstance.isRTL,
+      },
+      docxDocumentInstance
+    );
     xmlFragment.import(paragraphFragment);
   }
   return xmlFragment;

--- a/src/schemas/document.template.js
+++ b/src/schemas/document.template.js
@@ -1,35 +1,35 @@
 import namespaces from '../namespaces';
 
-const generateDocumentTemplate = (width, height, orientation, margins) => `
-  <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-
-    <w:document
-        xmlns:a="${namespaces.a}"
-        xmlns:cdr="${namespaces.cdr}"
-        xmlns:o="${namespaces.o}"
-        xmlns:pic="${namespaces.pic}"
-        xmlns:r="${namespaces.r}"
-        xmlns:v="${namespaces.v}"
-        xmlns:ve="${namespaces.ve}"
-        xmlns:vt="${namespaces.vt}"
-        xmlns:w="${namespaces.w}"
-        xmlns:w10="${namespaces.w10}"
-        xmlns:wp="${namespaces.wp}"
-        xmlns:wne="${namespaces.wne}"
-        >
-        <w:body>
-            <w:sectPr>
-                <w:pgSz w:w="${width}" w:h="${height}" w:orient="${orientation}" />
-                <w:pgMar w:top="${margins.top}"
-                        w:right="${margins.right}"
-                        w:bottom="${margins.bottom}"
-                        w:left="${margins.left}"
-                        w:header="${margins.header}"
-                        w:footer="${margins.footer}"
-                        w:gutter="${margins.gutter}"/>
-            </w:sectPr>
-        </w:body>
-    </w:document>
-  `;
+const generateDocumentTemplate = (width, height, orientation, margins, isRTL = false) => `
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document
+    xmlns:a="${namespaces.a}"
+    xmlns:cdr="${namespaces.cdr}"
+    xmlns:o="${namespaces.o}"
+    xmlns:pic="${namespaces.pic}"
+    xmlns:r="${namespaces.r}"
+    xmlns:v="${namespaces.v}"
+    xmlns:ve="${namespaces.ve}"
+    xmlns:vt="${namespaces.vt}"
+    xmlns:w="${namespaces.w}"
+    xmlns:w10="${namespaces.w10}"
+    xmlns:wp="${namespaces.wp}"
+    xmlns:wne="${namespaces.wne}"
+    >
+    <w:body>
+        <w:sectPr>
+            <w:pgSz w:w="${width}" w:h="${height}" w:orient="${orientation}" />
+            <w:pgMar w:top="${margins.top}"
+                    w:right="${margins.right}"
+                    w:bottom="${margins.bottom}"
+                    w:left="${margins.left}"
+                    w:header="${margins.header}"
+                    w:footer="${margins.footer}"
+                    w:gutter="${margins.gutter}"/>
+            ${isRTL ? '<w:bidi/>' : ''}
+        </w:sectPr>
+    </w:body>
+</w:document>
+`;
 
 export default generateDocumentTemplate;


### PR DESCRIPTION
This pull request introduces support for generating Right-to-Left (RTL) documents and includes several updates to the codebase to accommodate this feature. The changes span multiple files, adding an `isRTL` property to the `DocxDocument` class and propagating this flag through various document rendering functions. Additionally, the `package.json` file has been updated to reflect the new project name and remove unused dependencies.

### RTL Support Enhancements:
* [`src/docx-document.js`](diffhunk://#diff-5b846b657e5ac22b8a0365d30327436acd20c030038989e5bd0b6b43581a75ccR119): Added an `isRTL` property to the `DocxDocument` class and passed it to the `generateDocumentTemplate` function. [[1]](diffhunk://#diff-5b846b657e5ac22b8a0365d30327436acd20c030038989e5bd0b6b43581a75ccR119) [[2]](diffhunk://#diff-5b846b657e5ac22b8a0365d30327436acd20c030038989e5bd0b6b43581a75ccL215-R216)
* [`src/helpers/render-document-file.js`](diffhunk://#diff-e1d038613b8cd12085723b4db2e0ed2187ed0a81cc4fdf461fa61a9fbea2452fR81): Updated multiple functions to pass the `isRTL` flag to XML builders for paragraphs, tables, images, and other document elements. [[1]](diffhunk://#diff-e1d038613b8cd12085723b4db2e0ed2187ed0a81cc4fdf461fa61a9fbea2452fR81) [[2]](diffhunk://#diff-e1d038613b8cd12085723b4db2e0ed2187ed0a81cc4fdf461fa61a9fbea2452fR114) [[3]](diffhunk://#diff-e1d038613b8cd12085723b4db2e0ed2187ed0a81cc4fdf461fa61a9fbea2452fR232) [[4]](diffhunk://#diff-e1d038613b8cd12085723b4db2e0ed2187ed0a81cc4fdf461fa61a9fbea2452fL253-R262) [[5]](diffhunk://#diff-e1d038613b8cd12085723b4db2e0ed2187ed0a81cc4fdf461fa61a9fbea2452fR276-R285) [[6]](diffhunk://#diff-e1d038613b8cd12085723b4db2e0ed2187ed0a81cc4fdf461fa61a9fbea2452fR303-R312) [[7]](diffhunk://#diff-e1d038613b8cd12085723b4db2e0ed2187ed0a81cc4fdf461fa61a9fbea2452fL312-R329) [[8]](diffhunk://#diff-e1d038613b8cd12085723b4db2e0ed2187ed0a81cc4fdf461fa61a9fbea2452fL343-R366)
* [`src/schemas/document.template.js`](diffhunk://#diff-793e4a661255597ed63dd95877d795060a96e722db2ab92b942a2d9c9b5450f6L3-L5): Modified the `generateDocumentTemplate` function to accept an `isRTL` parameter and include `<w:bidi/>` in the document XML when RTL is enabled. [[1]](diffhunk://#diff-793e4a661255597ed63dd95877d795060a96e722db2ab92b942a2d9c9b5450f6L3-L5) [[2]](diffhunk://#diff-793e4a661255597ed63dd95877d795060a96e722db2ab92b942a2d9c9b5450f6R29)

### Project Metadata Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2): Changed the project name to `html-to-docx-rtl`, removed the `husky` dependency, and updated the `scripts` section to exclude the `prepare` script. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L48-R48) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L97)