### PR TITLE
fix: prevent TypeError when processing tables with colspan/rowspan attributes

### DIFF
--- a/example/example-node.js
+++ b/example/example-node.js
@@ -1863,6 +1863,35 @@ const htmlString = `<!DOCTYPE html>
                 alt="Oversized image that should auto-scale"
             />
         </div>
+        <!-- Test case for GitHub issue #88: tables with colspan and rowspan attributes -->
+        <table style="min-width: 100%;">
+          <colgroup>
+            <col style="min-width: 25px">
+            <col style="min-width: 25px">
+            <col style="min-width: 25px">
+          </colgroup>
+          <tbody>
+            <tr>
+              <th colspan="2" rowspan="1">
+                <p>testset</p>
+              </th>
+              <th colspan="1" rowspan="1">
+                <p>test</p>
+              </th>
+            </tr>
+            <tr>
+              <td colspan="1" rowspan="2">
+                <p>data1</p>
+              </td>
+              <td colspan="1" rowspan="1">
+                <p>data2</p>
+              </td>
+              <td colspan="1" rowspan="1">
+                <p>data3</p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
     </body>
 </html>`;
 

--- a/example/example.js
+++ b/example/example.js
@@ -1836,6 +1836,35 @@ const htmlString = `<!DOCTYPE html>
                 alt="Oversized image that should auto-scale"
             />
         </div>
+        <!-- Test case for GitHub issue #88: tables with colspan and rowspan attributes -->
+        <table style="min-width: 100%;">
+          <colgroup>
+            <col style="min-width: 25px">
+            <col style="min-width: 25px">
+            <col style="min-width: 25px">
+          </colgroup>
+          <tbody>
+            <tr>
+              <th colspan="2" rowspan="1">
+                <p>testset</p>
+              </th>
+              <th colspan="1" rowspan="1">
+                <p>test</p>
+              </th>
+            </tr>
+            <tr>
+              <td colspan="1" rowspan="2">
+                <p>data1</p>
+              </td>
+              <td colspan="1" rowspan="1">
+                <p>data2</p>
+              </td>
+              <td colspan="1" rowspan="1">
+                <p>data3</p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
     </body>
 </html>`;
 

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -1027,7 +1027,7 @@ const buildRun = async (vNode, attributes, docxDocumentInstance) => {
 };
 
 const buildRunOrRuns = async (vNode, attributes, docxDocumentInstance) => {
-  if ((isVNode(vNode) || vNode?.isCoveringNode) && vNode.tagName === 'span') {
+  if ((isVNode(vNode) || vNode?.isCoveringNode) && vNode.tagName === 'span' && vNode.children) {
     let runFragments = [];
 
     for (let index = 0; index < vNode.children.length; index++) {
@@ -1064,7 +1064,8 @@ const buildRunOrHyperLink = async (vNode, attributes, docxDocumentInstance) => {
       .ele('@w', 'hyperlink')
       .att('@r', 'id', `rId${relationshipId}`);
 
-    for (let idx = 0; idx < vNode.children.length; idx++) {
+    if (vNode.children) {
+      for (let idx = 0; idx < vNode.children.length; idx++) {
       const childVNode = vNode.children[idx];
       const modifiedAttributes =
         isVNode(childVNode) && childVNode.tagName === 'img'
@@ -1084,6 +1085,7 @@ const buildRunOrHyperLink = async (vNode, attributes, docxDocumentInstance) => {
         }
       } else {
         hyperlinkFragment.import(runFragments);
+      }
       }
     }
 
@@ -1470,7 +1472,7 @@ const buildParagraph = async (vNode, attributes, docxDocumentInstance) => {
       } else {
         paragraphFragment.import(runFragmentOrFragments);
       }
-    } else {
+    } else if (vNode.children) {
       for (let index = 0; index < vNode.children.length; index++) {
         const childVNode = vNode.children[index];
         if (childVNode.tagName === 'img') {
@@ -2392,7 +2394,7 @@ const buildTableCell = async (vNode, attributes, rowSpanMap, columnIndex, docxDo
       // if rowSpan is happening, then there must be some border properties.
       const spanObject = { rowSpan: vNode.properties.rowSpan - 1, colSpan: 0 };
       const { style } = vNode.properties;
-      const styleKeys = Object.keys(style)
+      const styleKeys = style ? Object.keys(style) : [];
       for (const styleKey of styleKeys) {
         // separately set the properties for 4 directions in case shorthands are given
         // as we use directional properties indiviually to generate border


### PR DESCRIPTION
## Summary
Fixes #88 - TypeError when processing HTML tables with colspan and rowspan attributes.

## Root Cause
The library was attempting to call `Object.keys(style)` on a potentially undefined `style` property when processing table cells with `rowspan` attributes, causing a `TypeError: Cannot convert undefined or null to object`.

## Changes Made
- **Fixed Object.keys() bug**: Added null check in `src/helpers/xml-builder.js:2343`
- **Added defensive programming**: Fixed 3 additional potential crashes where `vNode.children` was accessed without checking if it exists
- **Added regression tests**: Updated all example files with test cases for colspan/rowspan tables

## Testing
- ✅ Reproduces the original bug
- ✅ Fixes the TypeError
- ✅ Successfully generates DOCX files with colspan/rowspan tables
- ✅ All existing functionality preserved

## Files Changed
- `src/helpers/xml-builder.js` - Core bug fixes
- `example/example-node.js` - Added test case
- `example/example.js` - Added test case  

🤖 Generated with [Claude Code](https://claude.ai/code)