### PR TITLE
refactor: clean up messy if-else statements in TypeScript example

### DIFF
--- a/example/typescript/typescript-example.ts
+++ b/example/typescript/typescript-example.ts
@@ -47,27 +47,43 @@ const htmlString = `<!DOCTYPE html>
 
 const headerHtml = `<p style="text-align: right;">TurboDocx Example</p>`;
 const footerHtml = `<p style="text-align: center;">Page <span id="pageNumber">X</span> of <span id="totalPages">Y</span></p>`;
-
-async function saveDocxFile(docResult: Buffer | ArrayBuffer | Blob, fileName: string, docType: string) {
-    let docData: Buffer;
-    if (docResult instanceof Buffer) {
-        docData = docResult;
-    } else if (docResult instanceof ArrayBuffer) {
-        docData = Buffer.from(docResult);
-    } else if (typeof Blob !== 'undefined' && docResult instanceof Blob) {
-        console.log(`Received Blob for ${docType}, converting to ArrayBuffer then Buffer...`);
-        const arrayBuffer = await docResult.arrayBuffer();
-        docData = Buffer.from(arrayBuffer);
-    } else {
-        console.error(`Unexpected result type for ${docType}:`, typeof docResult);
-        // @ts-ignore
-        console.log(`${docType} constructor name:`, docResult?.constructor?.name);
+async function saveDocxFile(
+  docResult: Buffer | ArrayBuffer | Blob,
+  fileName: string,
+  docType: string
+) {
+  let docData: Buffer;
+  switch (typeof docResult) {
+    case 'object':
+      if (docResult === null) {
+        console.error(`docResult is null for ${docType}`);
         return;
-    }
-    fs.writeFileSync(path.join(__dirname, fileName), docData);
-    console.log(`${docType} document created: ${fileName}`);
-}
+      }
+      switch (docResult.constructor?.name) {
+        case 'Buffer':
+          docData = docResult as Buffer;
+          break;
+        case 'ArrayBuffer':
+          docData = Buffer.from(docResult as ArrayBuffer);
+          break;
+        case 'Blob':
+          console.log(`Received Blob for ${docType}, converting to ArrayBuffer then Buffer...`);
+          const arrayBuffer = await (docResult as Blob).arrayBuffer();
+          docData = Buffer.from(arrayBuffer);
+          break;
+        default:
+          console.error(`Unexpected object type for ${docType}:`, docResult.constructor?.name);
+          return;
+      }
+      break;
+    default:
+      console.error(`Unexpected result type for ${docType}:`, typeof docResult);
+      return;
+  }
 
+  fs.writeFileSync(path.join(__dirname, fileName), docData);
+  console.log(`${docType} document created: ${fileName}`);
+}
 async function generateDocuments() {
     try {
         // Basic example


### PR DESCRIPTION
- Simplified type checking logic in saveDocxFile function
- Replaced nested if-else chains with cleaner switch statements
- Improved readability and maintainability of type handling code
- Better error handling for unexpected object types