### PR TITLE
fix: correct output filenames in example console logs

### DIFF
--- a/example/example-node.js
+++ b/example/example-node.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 // const HTMLtoDOCX = require('html-to-docx');
 const HTMLtoDOCX = require('../dist/html-to-docx.umd');
 
-const filePath = './example.docx';
+const filePath = './example-node.docx';
 
 const htmlString = `<!DOCTYPE html>
 <html lang="en">

--- a/example/example-rtl.js
+++ b/example/example-rtl.js
@@ -37,7 +37,7 @@ async function generateDoc() {
 
   // Save the buffer to file
   fs.writeFileSync('example-rtl.docx', docxBuffer);
-  console.log('✅ DOCX created: test.docx');
+  console.log('✅ DOCX created: example-rtl.docx');
 }
 
 generateDoc();

--- a/example/react-example/src/example-rtl.js
+++ b/example/react-example/src/example-rtl.js
@@ -37,7 +37,7 @@ async function generateDoc() {
 
   // Save the buffer to file
   fs.writeFileSync('example-rtl.docx', docxBuffer);
-  console.log('✅ DOCX created: test.docx');
+  console.log('✅ DOCX created: example-rtl.docx');
 }
 
 generateDoc();


### PR DESCRIPTION
## Summary
- Fixed console.log messages in example files to match their actual output filenames
- Ensures consistency between what the code outputs and what the console displays

## Changes
- `example/example-node.js`: Changed output filename from `example.docx` to `example-node.docx`
- `example/example-rtl.js`: Fixed console message to show `example-rtl.docx` instead of `test.docx`
- `example/react-example/src/example-rtl.js`: Fixed console message to show `example-rtl.docx` instead of `test.docx`

## Test plan
- [x] Run `node example/example-node.js` and verify it creates `example-node.docx`
- [x] Run `node example/example-rtl.js` and verify console shows correct filename
- [x] Verify React example RTL file shows correct output filename

🤖 Generated with [Claude Code](https://claude.ai/code)