### PR TITLE
feat: add customizable heading styles configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ full fledged examples can be found under `example/`
     - `restart` <"continuous"|"newPage"|"newSection"> numbering restart strategy. Defaults to `continuous`.
   - `numbering` <?[Object]>
     - `defaultOrderedListStyleType` <?[String]> default ordered list style type. Defaults to `decimal`.
+  - `heading` <?[Object]> custom heading styles configuration
+  - `heading1`-`heading6` <?[Object]> heading style configuration
+    - `font` <?[String]> font family
+    - `fontSize` <?[Number]> font size in half-points
+    - `bold` <?[Boolean]> whether text is bold. Defaults to `true`
+    - `spacing` <?[Object]> paragraph spacing configuration
+      - `before` <?[Number]> spacing before heading in twips
+      - `after` <?[Number]> spacing after heading in twips
+    - `keepLines` <?[Boolean]> keep lines together. Defaults to `true`
+    - `keepNext` <?[Boolean]> keep with next paragraph. Defaults to `true`
+    - `outlineLevel` <?[Number]> outline level (0-5)
   - `decodeUnicode` <?[Boolean]> flag to enable unicode decoding of header, body and footer. Defaults to `false`.
   - `lang` <?[String]> language localization code for spell checker to work properly. Defaults to `en-US`.
   - `direction` <?[String]> text direction for RTL (right-to-left) languages. Set to `'rtl'` for Arabic, Hebrew, etc. Defaults to `'ltr'`.

--- a/src/constants.js
+++ b/src/constants.js
@@ -76,6 +76,62 @@ const defaultDocumentOptions = {
   numbering: {
     defaultOrderedListStyleType: 'decimal',
   },
+  heading: {
+    heading1: {
+      font: null, // use default font
+      fontSize: 48,
+      bold: true,
+      spacing: { before: 480, after: 0 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 0,
+    },
+    heading2: {
+      font: null, // use default font
+      fontSize: 36,
+      bold: true,
+      spacing: { before: 360, after: 80 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 1,
+    },
+    heading3: {
+      font: null, // use default font
+      fontSize: 28,
+      bold: true,
+      spacing: { before: 280, after: 80 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 2,
+    },
+    heading4: {
+      font: null, // use default font
+      fontSize: 24,
+      bold: true,
+      spacing: { before: 240, after: 40 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 3,
+    },
+    heading5: {
+      font: null, // use default font
+      fontSize: null, // use default font size
+      bold: true,
+      spacing: { before: 220, after: 40 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 4,
+    },
+    heading6: {
+      font: null, // use default font
+      fontSize: 20,
+      bold: true,
+      spacing: { before: 200, after: 40 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 5,
+    },
+  },
   decodeUnicode: false,
   defaultLang,
   direction: defaultDirection,

--- a/src/docx-document.js
+++ b/src/docx-document.js
@@ -190,6 +190,7 @@ class DocxDocument {
       properties.table && properties.table.addSpacingAfter !== undefined
         ? properties.table.addSpacingAfter
         : defaultDocumentOptions.table.addSpacingAfter;
+    this.heading = properties.heading || defaultDocumentOptions.heading;
     this.lastNumberingId = 0;
     this.lastMediaId = 0;
     this.lastHeaderId = 0;
@@ -295,7 +296,13 @@ class DocxDocument {
 
   generateStylesXML() {
     return generateXMLString(
-      generateStylesXML(this.font, this.fontSize, this.complexScriptFontSize, this.lang),
+      generateStylesXML(
+        this.font,
+        this.fontSize,
+        this.complexScriptFontSize,
+        this.lang,
+        this.heading
+      ),
       this.direction
     );
   }

--- a/src/schemas/styles.js
+++ b/src/schemas/styles.js
@@ -5,8 +5,73 @@ const generateStylesXML = (
   font = defaultFont,
   fontSize = defaultFontSize,
   complexScriptFontSize = defaultFontSize,
-  lang = defaultLang
-) => `
+  lang = defaultLang,
+  headingConfig = null
+) => {
+  // default heading configuration (if not provided)
+  const defaultHeadingConfig = {
+    heading1: {
+      font: null, // use default font
+      fontSize: 48,
+      bold: true,
+      spacing: { before: 480, after: 0 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 0,
+    },
+    heading2: {
+      font: null, // use default font
+      fontSize: 36,
+      bold: true,
+      spacing: { before: 360, after: 80 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 1,
+    },
+    heading3: {
+      font: null, // use default font
+      fontSize: 28,
+      bold: true,
+      spacing: { before: 280, after: 80 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 2,
+    },
+    heading4: {
+      font: null, // use default font
+      fontSize: 24,
+      bold: true,
+      spacing: { before: 240, after: 40 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 3,
+    },
+    heading5: {
+      font: null, // use default font
+      fontSize: null, // use default font size
+      bold: true,
+      spacing: { before: 220, after: 40 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 4,
+    },
+    heading6: {
+      font: null, // use default font
+      fontSize: 20,
+      bold: true,
+      spacing: { before: 200, after: 40 },
+      keepLines: true,
+      keepNext: true,
+      outlineLevel: 5,
+    },
+  };
+
+  // merge configuration
+  const config = headingConfig
+    ? { ...defaultHeadingConfig, ...headingConfig }
+    : defaultHeadingConfig;
+
+  return `
   <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
   <w:styles xmlns:w="${namespaces.w}" xmlns:r="${namespaces.r}">
@@ -42,15 +107,22 @@ const generateStylesXML = (
 	  <w:uiPriority w:val="9" />
 	  <w:qFormat />
 	  <w:pPr>
-		<w:keepNext />
-		<w:keepLines />
-		<w:spacing w:before="480" />
-		<w:outlineLvl w:val="0" />
+		${config.heading1.keepLines ? '<w:keepLines />' : ''}
+		${config.heading1.keepNext ? '<w:keepNext />' : ''}
+		<w:spacing w:before="${config.heading1.spacing.before}" ${
+    config.heading1.spacing.after ? `w:after="${config.heading1.spacing.after}"` : ''
+  } />
+		<w:outlineLvl w:val="${config.heading1.outlineLevel || 0}" />
 	  </w:pPr>
 	  <w:rPr>
-		<w:b />
-		<w:sz w:val="48" />
-		<w:szCs w:val="48" />
+		${
+      config.heading1.font
+        ? `<w:rFonts w:ascii="${config.heading1.font}" w:eastAsiaTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi" w:cstheme="minorBidi" />`
+        : ''
+    }
+		${config.heading1.bold ? '<w:b />' : ''}
+		${config.heading1.fontSize ? `<w:sz w:val="${config.heading1.fontSize}" />` : ''}
+		${config.heading1.fontSize ? `<w:szCs w:val="${config.heading1.fontSize}" />` : ''}
 	  </w:rPr>
 	</w:style>
 	<w:style w:type="paragraph" w:styleId="Heading2">
@@ -61,15 +133,22 @@ const generateStylesXML = (
 	  <w:unhideWhenUsed />
 	  <w:qFormat />
 	  <w:pPr>
-		<w:keepNext />
-		<w:keepLines />
-		<w:spacing w:before="360" w:after="80" />
-		<w:outlineLvl w:val="1" />
+		${config.heading2.keepLines ? '<w:keepLines />' : ''}
+		${config.heading2.keepNext ? '<w:keepNext />' : ''}
+		<w:spacing w:before="${config.heading2.spacing.before}" ${
+    config.heading2.spacing.after ? `w:after="${config.heading2.spacing.after}"` : ''
+  } />
+		<w:outlineLvl w:val="${config.heading2.outlineLevel || 1}" />
 	  </w:pPr>
 	  <w:rPr>
-		<w:b />
-		<w:sz w:val="36" />
-		<w:szCs w:val="36" />
+		${
+      config.heading2.font
+        ? `<w:rFonts w:ascii="${config.heading2.font}" w:eastAsiaTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi" w:cstheme="minorBidi" />`
+        : ''
+    }
+		${config.heading2.bold ? '<w:b />' : ''}
+		${config.heading2.fontSize ? `<w:sz w:val="${config.heading2.fontSize}" />` : ''}
+		${config.heading2.fontSize ? `<w:szCs w:val="${config.heading2.fontSize}" />` : ''}
 	  </w:rPr>
 	</w:style>
 	<w:style w:type="paragraph" w:styleId="Heading3">
@@ -81,15 +160,22 @@ const generateStylesXML = (
 	  <w:unhideWhenUsed />
 	  <w:qFormat />
 	  <w:pPr>
-		<w:keepNext />
-		<w:keepLines />
-		<w:spacing w:before="280" w:after="80" />
-		<w:outlineLvl w:val="2" />
+		${config.heading3.keepLines ? '<w:keepLines />' : ''}
+		${config.heading3.keepNext ? '<w:keepNext />' : ''}
+		<w:spacing w:before="${config.heading3.spacing.before}" ${
+    config.heading3.spacing.after ? `w:after="${config.heading3.spacing.after}"` : ''
+  } />
+		<w:outlineLvl w:val="${config.heading3.outlineLevel || 2}" />
 	  </w:pPr>
 	  <w:rPr>
-		<w:b />
-		<w:sz w:val="28" />
-		<w:szCs w:val="28" />
+		${
+      config.heading3.font
+        ? `<w:rFonts w:ascii="${config.heading3.font}" w:eastAsiaTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi" w:cstheme="minorBidi" />`
+        : ''
+    }
+		${config.heading3.bold ? '<w:b />' : ''}
+		${config.heading3.fontSize ? `<w:sz w:val="${config.heading3.fontSize}" />` : ''}
+		${config.heading3.fontSize ? `<w:szCs w:val="${config.heading3.fontSize}" />` : ''}
 	  </w:rPr>
 	</w:style>
 	<w:style w:type="paragraph" w:styleId="Heading4">
@@ -101,15 +187,22 @@ const generateStylesXML = (
 	  <w:unhideWhenUsed />
 	  <w:qFormat />
 	  <w:pPr>
-		<w:keepNext />
-		<w:keepLines />
-		<w:spacing w:before="240" w:after="40" />
-		<w:outlineLvl w:val="3" />
+		${config.heading4.keepLines ? '<w:keepLines />' : ''}
+		${config.heading4.keepNext ? '<w:keepNext />' : ''}
+		<w:spacing w:before="${config.heading4.spacing.before}" ${
+    config.heading4.spacing.after ? `w:after="${config.heading4.spacing.after}"` : ''
+  } />
+		<w:outlineLvl w:val="${config.heading4.outlineLevel || 3}" />
 	  </w:pPr>
 	  <w:rPr>
-		<w:b />
-		<w:sz w:val="24" />
-		<w:szCs w:val="24" />
+		${
+      config.heading4.font
+        ? `<w:rFonts w:ascii="${config.heading4.font}" w:eastAsiaTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi" w:cstheme="minorBidi" />`
+        : ''
+    }
+		${config.heading4.bold ? '<w:b />' : ''}
+		${config.heading4.fontSize ? `<w:sz w:val="${config.heading4.fontSize}" />` : ''}
+		${config.heading4.fontSize ? `<w:szCs w:val="${config.heading4.fontSize}" />` : ''}
 	  </w:rPr>
 	</w:style>
 	<w:style w:type="paragraph" w:styleId="Heading5">
@@ -121,13 +214,22 @@ const generateStylesXML = (
 	  <w:unhideWhenUsed />
 	  <w:qFormat />
 	  <w:pPr>
-		<w:keepNext />
-		<w:keepLines />
-		<w:spacing w:before="220" w:after="40" />
-		<w:outlineLvl w:val="4" />
+		${config.heading5.keepLines ? '<w:keepLines />' : ''}
+		${config.heading5.keepNext ? '<w:keepNext />' : ''}
+		<w:spacing w:before="${config.heading5.spacing.before}" ${
+    config.heading5.spacing.after ? `w:after="${config.heading5.spacing.after}"` : ''
+  } />
+		<w:outlineLvl w:val="${config.heading5.outlineLevel || 4}" />
 	  </w:pPr>
 	  <w:rPr>
-		<w:b />
+		${
+      config.heading5.font
+        ? `<w:rFonts w:ascii="${config.heading5.font}" w:eastAsiaTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi" w:cstheme="minorBidi" />`
+        : ''
+    }
+		${config.heading5.bold ? '<w:b />' : ''}
+		${config.heading5.fontSize ? `<w:sz w:val="${config.heading5.fontSize}" />` : ''}
+		${config.heading5.fontSize ? `<w:szCs w:val="${config.heading5.fontSize}" />` : ''}
 	  </w:rPr>
 	</w:style>
 	<w:style w:type="paragraph" w:styleId="Heading6">
@@ -139,18 +241,26 @@ const generateStylesXML = (
 	  <w:unhideWhenUsed />
 	  <w:qFormat />
 	  <w:pPr>
-		<w:keepNext />
-		<w:keepLines />
-		<w:spacing w:before="200" w:after="40" />
-		<w:outlineLvl w:val="5" />
+		${config.heading6.keepLines ? '<w:keepLines />' : ''}
+		${config.heading6.keepNext ? '<w:keepNext />' : ''}
+		<w:spacing w:before="${config.heading6.spacing.before}" ${
+    config.heading6.spacing.after ? `w:after="${config.heading6.spacing.after}"` : ''
+  } />
+		<w:outlineLvl w:val="${config.heading6.outlineLevel || 5}" />
 	  </w:pPr>
 	  <w:rPr>
-		<w:b />
-		<w:sz w:val="20" />
-		<w:szCs w:val="20" />
+		${
+      config.heading6.font
+        ? `<w:rFonts w:ascii="${config.heading6.font}" w:eastAsiaTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi" w:cstheme="minorBidi" />`
+        : ''
+    }
+		${config.heading6.bold ? '<w:b />' : ''}
+		${config.heading6.fontSize ? `<w:sz w:val="${config.heading6.fontSize}" />` : ''}
+		${config.heading6.fontSize ? `<w:szCs w:val="${config.heading6.fontSize}" />` : ''}
 	  </w:rPr>
 	</w:style>
   </w:styles>
   `;
+};
 
 export default generateStylesXML;


### PR DESCRIPTION
Add heading configuration options to document options with support for:
- Custom font family, font size, and formatting for headings 1-6
- Configurable paragraph spacing before and after headings
- Keep lines and keep next paragraph options
- Outline level configuration for document structure
- Merge user heading config with default settings