### PR TITLE
Add CodeQL security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+  schedule:
+    - cron: '0 0 * * 1'  # Weekly on Mondays at midnight UTC
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-extended,security-and-quality
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 @turbodocx/html-to-docx
 ====================
 [![NPM Version][npm-image]][npm-url]
+[![CodeQL](https://github.com/TurboDocx/html-to-docx/workflows/CodeQL/badge.svg)](https://github.com/TurboDocx/html-to-docx/actions/workflows/codeql.yml)
 [![GitHub Stars](https://img.shields.io/github/stars/turbodocx/html-to-docx?style=social)](https://github.com/turbodocx/html-to-docx)
 [![Type Script](https://shields.io/badge/TypeScript-3178C6?logo=TypeScript&logoColor=FFF&style=flat-square)](https://typescript.org)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord)](https://discord.gg/NYKwz4BcpX)


### PR DESCRIPTION
## Summary
- Add automated security analysis with CodeQL workflow
- Configure weekly scans and analysis on push/PR
- Add CodeQL badge to README

## Changes
- Created `.github/workflows/codeql.yml` workflow that:
  - Runs on push/PR to main and develop branches
  - Runs weekly scheduled scans (Mondays at midnight UTC)
  - Uses security-extended and security-and-quality query suites
  - Analyzes JavaScript codebase
- Added CodeQL workflow badge to README

## Test plan
- [x] Workflow file syntax validated
- [x] Badge URL points to correct workflow
- [ ] Verify workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)