### PR TITLE
feat: support page-break-before: always (#175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,14 @@ full fledged examples can be found under `example/`
 
 ## Notes
 
-Currently page break can be implemented by having div with classname "page-break" or style "page-break-after" despite the values of the "page-break-after", and contents inside the div element will be ignored. `<div class="page-break" style="page-break-after: always;"></div>`
+Page breaks can be added using CSS `page-break-before: always` or `page-break-after` on any block element (`<p>`, `<h1>`–`<h6>`, `<div>`, etc.):
+```html
+<p style="page-break-before: always;">This paragraph starts on a new page</p>
+<p style="page-break-after: always;">A page break follows this paragraph</p>
+<div style="page-break-before: always;"><p>Content on new page</p></div>
+```
+`page-break-before` only triggers on the value `always`. `page-break-after` triggers on any value for backward compatibility.
+The legacy `<div class="page-break"></div>` pattern is still supported for backward compatibility (contents inside are ignored).
 
 
 CSS list-style-type for `<ol>` element are now supported. Just do something like this in the HTML:

--- a/example/example-node.js
+++ b/example/example-node.js
@@ -2039,7 +2039,41 @@ const htmlString = `<!DOCTYPE html>
         <p>This is a <span style="text-decoration: line-through;">strikethough</span> test.</p>
         <p>This is a <em><del>strikethough</del></em> test.</p>
         <p>This is a <b><del>strikethough</del></b> test.</p>
-        
+
+        <h1>Page Break Tests (PR #187)</h1>
+        <p>The following section demonstrates CSS page-break support. The next heading uses
+           <code>style="page-break-before: always"</code> and should start on a new page.</p>
+
+        <h1 style="page-break-before: always">page-break-before on a heading</h1>
+        <p>This heading was forced onto a new page via <code>page-break-before: always</code>.</p>
+
+        <p style="page-break-before: always">This paragraph also uses
+           <code>page-break-before: always</code> and starts its own page.</p>
+
+        <p style="page-break-after: always">This paragraph uses
+           <code>page-break-after: always</code> — content after it appears on the next page.</p>
+
+        <p>This sentence sits on a new page because of the preceding page-break-after.</p>
+
+        <h2>Legacy div.page-break (backward compatible)</h2>
+        <p>The original page-break marker still works:</p>
+        <div class="page-break"></div>
+        <p>This paragraph follows <code>&lt;div class="page-break"&gt;&lt;/div&gt;</code>.</p>
+
+        <h2>Divs with CSS page-break styles</h2>
+        <div style="page-break-before: always">
+            <p>This div uses <code>page-break-before: always</code>; its children render normally
+               but a page break is inserted before the div's content.</p>
+            <p>Multiple paragraphs inside the same div stay together on the new page.</p>
+        </div>
+
+        <div style="page-break-after: always">
+            <p>This div uses <code>page-break-after: always</code>; the break is emitted after the
+               div's last child.</p>
+        </div>
+
+        <p>Final paragraph — appears after the trailing page-break-after above.</p>
+
     </body>
 </html>`;
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "Srajan-Sanjay-Saxena",
     "jcasner",
     "demomacro",
-    "29217321"
+    "29217321",
+    "FultonG"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/helpers/render-document-file.js
+++ b/src/helpers/render-document-file.js
@@ -193,22 +193,66 @@ async function findXMLEquivalent(docxDocumentInstance, vNode, xmlFragment, image
   if (!imageOptions) {
     imageOptions = docxDocumentInstance.imageProcessing || defaultDocumentOptions.imageProcessing;
   }
-  if (
-    vNode.tagName === 'div' &&
-    (vNode.properties.attributes.class === 'page-break' ||
-      (vNode.properties.style && vNode.properties.style['page-break-after']))
-  ) {
-    const paragraphFragment = fragment({ namespaceAlias: { w: namespaces.w } })
-      .ele('@w', 'p')
-      .ele('@w', 'r')
-      .ele('@w', 'br')
-      .att('@w', 'type', 'page')
-      .up()
-      .up()
-      .up();
+  if (vNode.tagName === 'div') {
+    const divAttributes = vNode.properties.attributes || {};
 
-    xmlFragment.import(paragraphFragment);
-    return;
+    // Legacy backward compat: <div class="page-break"> — keep existing behavior exactly
+    if (divAttributes.class === 'page-break') {
+      const paragraphFragment = fragment({ namespaceAlias: { w: namespaces.w } })
+        .ele('@w', 'p')
+        .ele('@w', 'r')
+        .ele('@w', 'br')
+        .att('@w', 'type', 'page')
+        .up()
+        .up()
+        .up();
+      xmlFragment.import(paragraphFragment);
+      return;
+    }
+
+    const style = vNode.properties.style || {};
+    const hasBreakBefore = style['page-break-before'] === 'always';
+    // Accept any truthy value for backward compatibility
+    const hasBreakAfter = !!style['page-break-after'];
+
+    if (hasBreakBefore || hasBreakAfter) {
+      // page-break-before: insert empty paragraph with <w:pageBreakBefore/>
+      if (hasBreakBefore) {
+        const pbFragment = fragment({ namespaceAlias: { w: namespaces.w } })
+          .ele('@w', 'p')
+          .ele('@w', 'pPr')
+          .ele('@w', 'pageBreakBefore')
+          .up()
+          .up()
+          .up();
+        xmlFragment.import(pbFragment);
+      }
+
+      // Process children normally (no content loss)
+      if (vNodeHasChildren(vNode)) {
+        // eslint-disable-next-line no-plusplus
+        for (let index = 0; index < vNode.children.length; index++) {
+          const childVNode = vNode.children[index];
+          // eslint-disable-next-line no-use-before-define
+          await convertVTreeToXML(docxDocumentInstance, childVNode, xmlFragment, imageOptions);
+        }
+      }
+
+      // page-break-after: append empty paragraph with break run
+      if (hasBreakAfter) {
+        const paFragment = fragment({ namespaceAlias: { w: namespaces.w } })
+          .ele('@w', 'p')
+          .ele('@w', 'r')
+          .ele('@w', 'br')
+          .att('@w', 'type', 'page')
+          .up()
+          .up()
+          .up();
+        xmlFragment.import(paFragment);
+      }
+
+      return;
+    }
   }
 
   switch (vNode.tagName) {

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -676,6 +676,15 @@ const modifiedStyleAttributesBuilder = (docxDocumentInstance, vNode, attributes,
         if (vNodeStyleValue.trim() !== '' && vNodeStyleValue !== 'none') {
           modifiedAttributes.textShadow = vNodeStyleValue;
         }
+      } else if (vNodeStyleKey === 'page-break-before') {
+        if (vNodeStyleValue === 'always') {
+          modifiedAttributes.pageBreakBefore = true;
+        }
+      } else if (vNodeStyleKey === 'page-break-after') {
+        // Accept any truthy value for backward compatibility
+        if (vNodeStyleValue) {
+          modifiedAttributes.pageBreakAfter = true;
+        }
       }
     }
   }
@@ -1307,6 +1316,17 @@ const buildParagraphProperties = (attributes, docxDocumentInstance) => {
           paragraphPropertiesFragment.import(textDecorationFragment);
           // we don't delete attributes.textDecoration so that it could be inherited by children nodes.
           break;
+        // Note: pageBreakAfter is not handled here — OOXML has no paragraph property for it.
+        // It is handled in buildParagraph() as a trailing break run instead.
+        case 'pageBreakBefore':
+          // eslint-disable-next-line no-case-declarations
+          const pageBreakBeforeFragment = fragment({ namespaceAlias: { w: namespaces.w } })
+            .ele('@w', 'pageBreakBefore')
+            .up();
+          paragraphPropertiesFragment.import(pageBreakBeforeFragment);
+          // eslint-disable-next-line no-param-reassign
+          delete attributes.pageBreakBefore;
+          break;
       }
     });
 
@@ -1741,6 +1761,16 @@ const buildParagraph = async (vNode, attributes, docxDocumentInstance) => {
     } else {
       paragraphFragment.import(runFragments);
     }
+  }
+  if (modifiedAttributes.pageBreakAfter) {
+    const pageBreakRunFragment = fragment({ namespaceAlias: { w: namespaces.w } })
+      .ele('@w', 'r')
+      .ele('@w', 'br')
+      .att('@w', 'type', 'page')
+      .up()
+      .up();
+    paragraphFragment.import(pageBreakRunFragment);
+    delete modifiedAttributes.pageBreakAfter;
   }
   paragraphFragment.up();
 

--- a/tests/helpers/constants.js
+++ b/tests/helpers/constants.js
@@ -120,3 +120,32 @@ export const COLOR_REGEX = /<w:color w:val="([^"]+)"/;
  * Example: <w:sz w:val="48"/> → captures "48" (24pt font)
  */
 export const FONT_SIZE_REGEX = /<w:sz w:val="([^"]+)"/;
+
+// =============================================================================
+// PAGE BREAK PATTERNS
+// =============================================================================
+
+/**
+ * Matches a pageBreakBefore element in paragraph properties.
+ *
+ * What it matches: <w:pageBreakBefore/> or <w:pageBreakBefore />
+ * Used by: page-break tests
+ */
+export const PAGE_BREAK_BEFORE_REGEX = /<w:pageBreakBefore\s*\/>/;
+
+/**
+ * Matches a page break run element.
+ *
+ * What it matches: <w:br w:type="page"/> inside a run
+ * Used by: page-break tests
+ */
+export const PAGE_BREAK_RUN_REGEX = /<w:br[^>]*w:type="page"[^>]*\/>/;
+
+/**
+ * Matches a page break run element wrapped in a w:r element.
+ * Stricter than PAGE_BREAK_RUN_REGEX — verifies the break is inside a run.
+ *
+ * What it matches: <w:r><w:br w:type="page"/></w:r>
+ * Used by: XML structure verification tests
+ */
+export const PAGE_BREAK_RUN_IN_R_REGEX = /<w:r>\s*<w:br[^>]*w:type="page"[^>]*\/>\s*<\/w:r>/;

--- a/tests/helpers/docx-assertions.js
+++ b/tests/helpers/docx-assertions.js
@@ -9,6 +9,7 @@
  */
 
 import { parseDOCX } from './docx-validator.js';
+import { PAGE_BREAK_BEFORE_REGEX, PAGE_BREAK_RUN_REGEX } from './constants.js';
 
 // Re-export parseDOCX for convenience
 export { parseDOCX };
@@ -170,4 +171,34 @@ export function assertRunNoStrike(parsed, paragraphIndex, runIndex = 0) {
   }
 
   expect(para.runs[runIndex].strike).toBeFalsy();
+}
+
+/**
+ * Assert that a specific paragraph has a pageBreakBefore property in its pPr
+ * @param {Object} parsed - Parsed DOCX object from parseDOCX()
+ * @param {number} paragraphIndex - Zero-based paragraph index
+ */
+export function assertParagraphHasPageBreakBefore(parsed, paragraphIndex) {
+  const para = validateParagraphIndex(parsed, paragraphIndex, 'assertParagraphHasPageBreakBefore');
+  expect(para.xml).toMatch(PAGE_BREAK_BEFORE_REGEX);
+}
+
+/**
+ * Assert that a specific paragraph does NOT have a pageBreakBefore property
+ * @param {Object} parsed - Parsed DOCX object from parseDOCX()
+ * @param {number} paragraphIndex - Zero-based paragraph index
+ */
+export function assertParagraphNoPageBreakBefore(parsed, paragraphIndex) {
+  const para = validateParagraphIndex(parsed, paragraphIndex, 'assertParagraphNoPageBreakBefore');
+  expect(para.xml).not.toMatch(PAGE_BREAK_BEFORE_REGEX);
+}
+
+/**
+ * Assert that a specific paragraph has a page break run (w:br w:type="page")
+ * @param {Object} parsed - Parsed DOCX object from parseDOCX()
+ * @param {number} paragraphIndex - Zero-based paragraph index
+ */
+export function assertParagraphHasPageBreakRun(parsed, paragraphIndex) {
+  const para = validateParagraphIndex(parsed, paragraphIndex, 'assertParagraphHasPageBreakRun');
+  expect(para.xml).toMatch(PAGE_BREAK_RUN_REGEX);
 }

--- a/tests/page-break.test.js
+++ b/tests/page-break.test.js
@@ -1,0 +1,324 @@
+/**
+ * Page Break Integration Tests
+ * Tests for page-break-before and page-break-after CSS properties
+ *
+ * Related issue: https://github.com/TurboDocx/html-to-docx/issues/175
+ */
+
+import HTMLtoDOCX from '../index.js';
+import {
+  parseDOCX,
+  assertParagraphCount,
+  assertParagraphText,
+  assertParagraphHasPageBreakBefore,
+  assertParagraphNoPageBreakBefore,
+  assertParagraphHasPageBreakRun,
+} from './helpers/docx-assertions.js';
+import { PAGE_BREAK_BEFORE_REGEX, PAGE_BREAK_RUN_REGEX, PAGE_BREAK_RUN_IN_R_REGEX } from './helpers/constants.js';
+
+describe('Page Break Support', () => {
+  describe('page-break-before: always', () => {
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should add pageBreakBefore on a <p> element', async () => {
+      const htmlString = '<p>First paragraph</p><p style="page-break-before: always;">Second paragraph</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphCount(parsed, 2);
+      assertParagraphText(parsed, 0, 'First paragraph');
+      assertParagraphNoPageBreakBefore(parsed, 0);
+      assertParagraphText(parsed, 1, 'Second paragraph');
+      assertParagraphHasPageBreakBefore(parsed, 1);
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should add pageBreakBefore on heading elements', async () => {
+      const htmlString = '<p>Intro</p><h1 style="page-break-before: always;">Chapter 2</h1>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphCount(parsed, 2);
+      assertParagraphText(parsed, 1, 'Chapter 2');
+      assertParagraphHasPageBreakBefore(parsed, 1);
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should add pageBreakBefore on a <blockquote> element', async () => {
+      const htmlString = '<blockquote style="page-break-before: always;">Quote text</blockquote>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphCount(parsed, 1);
+      assertParagraphText(parsed, 0, 'Quote text');
+      assertParagraphHasPageBreakBefore(parsed, 0);
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should add pageBreakBefore on a <pre> element', async () => {
+      const htmlString = '<pre style="page-break-before: always;">Code text</pre>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphCount(parsed, 1);
+      assertParagraphText(parsed, 0, 'Code text');
+      assertParagraphHasPageBreakBefore(parsed, 0);
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should add pageBreakBefore on a <div> element', async () => {
+      const htmlString = '<p>Before</p><div style="page-break-before: always;"><p>After break</p></div>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      // paragraph "Before", empty paragraph with pageBreakBefore, paragraph "After break"
+      assertParagraphCount(parsed, 3);
+      assertParagraphText(parsed, 0, 'Before');
+      // The second paragraph should have pageBreakBefore (the empty one inserted by div handling)
+      assertParagraphHasPageBreakBefore(parsed, 1);
+      // Child content should be preserved
+      expect(parsed.xml).toContain('After break');
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should place pageBreakBefore inside w:pPr', async () => {
+      const htmlString = '<p style="page-break-before: always;">Content</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      // Verify the XML structure: pageBreakBefore should be inside pPr
+      const paraXml = parsed.paragraphs[0].xml;
+      const pPrMatch = paraXml.match(/<w:pPr>([\s\S]*?)<\/w:pPr>/);
+      expect(pPrMatch).not.toBeNull();
+      expect(pPrMatch[1]).toMatch(PAGE_BREAK_BEFORE_REGEX);
+    });
+  });
+
+  describe('page-break-after: always', () => {
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should add page break run after a <p> element', async () => {
+      const htmlString = '<p style="page-break-after: always;">First paragraph</p><p>Second paragraph</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphCount(parsed, 2);
+      assertParagraphText(parsed, 0, 'First paragraph');
+      // The first paragraph should contain a break run
+      assertParagraphHasPageBreakRun(parsed, 0);
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should add page break run after a heading', async () => {
+      const htmlString = '<h2 style="page-break-after: always;">Section End</h2><p>Next section</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphCount(parsed, 2);
+      assertParagraphText(parsed, 0, 'Section End');
+      assertParagraphHasPageBreakRun(parsed, 0);
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should produce w:br with type page inside w:r', async () => {
+      const htmlString = '<p style="page-break-after: always;">Content</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      const paraXml = parsed.paragraphs[0].xml;
+      expect(paraXml).toMatch(PAGE_BREAK_RUN_REGEX);
+      // Verify it's inside a run
+      expect(paraXml).toMatch(PAGE_BREAK_RUN_IN_R_REGEX);
+    });
+  });
+
+  describe('page-break-after on <div>', () => {
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should preserve children of div with page-break-after', async () => {
+      const htmlString = '<div style="page-break-after: always;"><p>Child content</p></div><p>After</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      // Child content should NOT be discarded
+      expect(parsed.xml).toContain('Child content');
+      expect(parsed.xml).toContain('After');
+      // Should have a page break run in the XML
+      expect(parsed.xml).toMatch(PAGE_BREAK_RUN_REGEX);
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should preserve children of div with page-break-before', async () => {
+      const htmlString = '<p>Before</p><div style="page-break-before: always;"><p>Child content</p></div>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      expect(parsed.xml).toContain('Before');
+      expect(parsed.xml).toContain('Child content');
+      expect(parsed.xml).toMatch(PAGE_BREAK_BEFORE_REGEX);
+    });
+  });
+
+  describe('Backward compatibility', () => {
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should support legacy <div class="page-break"> pattern', async () => {
+      const htmlString = '<p>Before</p><div class="page-break"></div><p>After</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphText(parsed, 0, 'Before');
+      // The page-break div generates a paragraph with a break run
+      assertParagraphHasPageBreakRun(parsed, 1);
+      assertParagraphText(parsed, 2, 'After');
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should prioritize class="page-break" over style when both are present', async () => {
+      // When class="page-break" is present, the legacy path fires (early return).
+      // The style attribute is never evaluated — this test verifies that behavior.
+      const htmlString = '<p>Before</p><div class="page-break" style="page-break-after: always;"></div><p>After</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphText(parsed, 0, 'Before');
+      assertParagraphHasPageBreakRun(parsed, 1);
+      assertParagraphText(parsed, 2, 'After');
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should handle page-break-after style on div without class="page-break"', async () => {
+      const htmlString = '<p>Before</p><div style="page-break-after: always;"><p>Div content</p></div><p>After</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      // Style-based path: children are preserved, break appended after
+      expect(parsed.xml).toContain('Div content');
+      expect(parsed.xml).toContain('After');
+      expect(parsed.xml).toMatch(PAGE_BREAK_RUN_REGEX);
+    });
+  });
+
+  describe('Value validation', () => {
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should NOT trigger break for page-break-before: auto', async () => {
+      const htmlString = '<p style="page-break-before: auto;">No break</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphCount(parsed, 1);
+      assertParagraphText(parsed, 0, 'No break');
+      assertParagraphNoPageBreakBefore(parsed, 0);
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should NOT trigger break for page-break-before: avoid', async () => {
+      const htmlString = '<p style="page-break-before: avoid;">No break</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphCount(parsed, 1);
+      assertParagraphNoPageBreakBefore(parsed, 0);
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should trigger break for page-break-after: auto (backward compat)', async () => {
+      const htmlString = '<p style="page-break-after: auto;">Break</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphCount(parsed, 1);
+      assertParagraphHasPageBreakRun(parsed, 0);
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should trigger break for page-break-after: avoid (backward compat)', async () => {
+      const htmlString = '<p style="page-break-after: avoid;">Break</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphCount(parsed, 1);
+      assertParagraphHasPageBreakRun(parsed, 0);
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should trigger break for any truthy page-break-after value (backward compat)', async () => {
+      const htmlString = '<p style="page-break-after: left;">Break</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphCount(parsed, 1);
+      assertParagraphHasPageBreakRun(parsed, 0);
+    });
+  });
+
+  describe('Combined page-break-before and page-break-after', () => {
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should handle both page-break-before and page-break-after on same element', async () => {
+      const htmlString = '<p>Before</p><p style="page-break-before: always; page-break-after: always;">Middle</p><p>After</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      assertParagraphText(parsed, 0, 'Before');
+      // The middle paragraph should have both
+      const middlePara = parsed.paragraphs[1];
+      expect(middlePara.xml).toMatch(PAGE_BREAK_BEFORE_REGEX);
+      expect(middlePara.xml).toMatch(PAGE_BREAK_RUN_REGEX);
+      expect(middlePara.text).toBe('Middle');
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should handle both breaks on a <div>', async () => {
+      const htmlString = '<p>Before</p><div style="page-break-before: always; page-break-after: always;"><p>Content</p></div><p>After</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      expect(parsed.xml).toContain('Before');
+      expect(parsed.xml).toContain('Content');
+      expect(parsed.xml).toContain('After');
+      expect(parsed.xml).toMatch(PAGE_BREAK_BEFORE_REGEX);
+      expect(parsed.xml).toMatch(PAGE_BREAK_RUN_REGEX);
+    });
+  });
+
+  describe('XML structure verification', () => {
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should generate correct XML for page-break-before', async () => {
+      const htmlString = '<p style="page-break-before: always;">Content</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      // Verify the raw XML contains pageBreakBefore
+      expect(parsed.xml).toContain('w:pageBreakBefore');
+    });
+
+    // https://github.com/TurboDocx/html-to-docx/issues/175
+    test('should generate correct XML for page-break-after', async () => {
+      const htmlString = '<p style="page-break-after: always;">Content</p>';
+
+      const result = await HTMLtoDOCX(htmlString, {});
+      const parsed = await parseDOCX(result);
+
+      // Verify the raw XML contains a page break run
+      expect(parsed.xml).toMatch(/<w:r>\s*<w:br[^>]*w:type="page"[^>]*\/>\s*<\/w:r>/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `page-break-before: always` support via the CSS pipeline, producing `<w:pageBreakBefore/>` in paragraph properties
- Refactor `page-break-after` handling on `<div>` elements to preserve child content instead of silently discarding it
- Maintain full backward compatibility with the legacy `<div class="page-break">` pattern and any-truthy-value behavior for `page-break-after`
- Guard against null-reference on `vNode.properties.attributes` for div elements

Closes #175

## Changes

- **`src/helpers/xml-builder.js`** — CSS property recognition for `page-break-before`/`page-break-after`, `<w:pageBreakBefore/>` in paragraph properties, trailing break run for page-break-after
- **`src/helpers/render-document-file.js`** — Refactored div handler: legacy `class="page-break"` preserved exactly, style-based breaks now process children normally
- **`README.md`** — Updated docs for both properties
- **`tests/page-break.test.js`** — 23 tests covering both properties, backward compat, value validation, combined breaks, XML structure
- **`tests/helpers/`** — New regex constants and assertion helpers

## Test plan

- [x] All 23 new page-break tests pass
- [x] All existing tests pass (no regressions)
- [x] Generated DOCX files verified: `page-break-before` produces `<w:pageBreakBefore/>` in `<w:pPr>`, `page-break-after` produces `<w:br w:type="page"/>` in trailing `<w:r>`
- [x] Open generated DOCX in Word/LibreOffice to verify page breaks render correctly