### PR TITLE
fix: preserve docx context for blockquote images

### DIFF
--- a/example/example-node.js
+++ b/example/example-node.js
@@ -123,6 +123,14 @@ const htmlString = `<!DOCTYPE html>
         <blockquote>
             For 50 years, WWF has been protecting the future of nature. The world's leading conservation organization, WWF works in 100 countries and is supported by 1.2 million members in the United States and close to 5 million globally.
         </blockquote>
+        <!-- Blockquote containing an image (regression coverage for PR #190) -->
+        <blockquote>
+            <img
+                src="data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
+                alt="Red dot inside a blockquote"
+            />
+            Image rendered inside a blockquote — exercises the docxDocumentInstance pass-through in buildRun().
+        </blockquote>
         <p>
             <strong>
                 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     "jcasner",
     "demomacro",
     "29217321",
-    "FultonG"
+    "FultonG",
+    "odex21"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -1672,7 +1672,7 @@ const buildParagraph = async (vNode, attributes, docxDocumentInstance) => {
         paragraphFragment.import(runOrHyperlinkFragments);
       }
     } else if (vNode.tagName === 'blockquote') {
-      const runFragmentOrFragments = await buildRun(vNode, attributes);
+      const runFragmentOrFragments = await buildRun(vNode, attributes, docxDocumentInstance);
       if (Array.isArray(runFragmentOrFragments)) {
         for (let index = 0; index < runFragmentOrFragments.length; index++) {
           paragraphFragment.import(runFragmentOrFragments[index]);

--- a/tests/image-processing.test.js
+++ b/tests/image-processing.test.js
@@ -204,6 +204,26 @@ describe('Image Processing', () => {
       // Should create document with text paragraphs, invalid image is skipped
       expect(parsed.paragraphs.length).toBeGreaterThanOrEqual(2);
     });
+
+    test('should handle data URL images inside blockquotes', async () => {
+      axios.get.mockClear();
+
+      const dataUrl = `data:image/png;base64,${PNG_1x1_BASE64}`;
+      const htmlString = `<blockquote><img src="${dataUrl}" alt="quoted image" /></blockquote>`;
+
+      const docx = await HTMLtoDOCX(htmlString, null, { fontSize: 24 });
+      const parsed = await parseDOCX(docx);
+      const mediaFiles = Object.keys(parsed.zip.files).filter((fileName) =>
+        fileName.startsWith('word/media/')
+      );
+
+      expect(docx).toBeDefined();
+      expect(Buffer.isBuffer(docx)).toBe(true);
+      expect(parsed.paragraphs.length).toBeGreaterThanOrEqual(1);
+      expect(mediaFiles.length).toBeGreaterThan(0);
+      expect(parsed.xml).toContain('<w:drawing>');
+      expect(axios.get).not.toHaveBeenCalled();
+    });
   });
 
   describe('Image dimension handling with data URLs', () => {


### PR DESCRIPTION
## Summary
- pass `docxDocumentInstance` through the `blockquote` rendering branch when calling `buildRun(...)`
- add a regression test covering a data URL image inside a `blockquote`

## Testing
- `npx jest tests/image-processing.test.js --runInBand --testNamePattern="should handle data URL images inside blockquotes"`

Closes #188