### PR TITLE
docs: add Agent Skill install path for AI-assisted setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ npm install @turbodocx/html-to-docx
 
 ### Install via Agent Skill (AI-assisted setup)
 
-[![skills.sh](https://skills.sh/b/TurboDocx/quickstart)](https://skills.sh/TurboDocx/quickstart)
-
 Skip the boilerplate. If you use Claude Code, GitHub Copilot, Cursor, OpenCode, OpenAI Codex CLI, or Gemini CLI, you can install the `turbodocx-html-to-docx` [Agent Skill](https://agentskills.io) and have your AI agent install the package, detect your framework, and generate working integration code in one step:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,6 +50,30 @@ Use the npm to install the project.
 npm install @turbodocx/html-to-docx
 ```
 
+### Install via Agent Skill (AI-assisted setup)
+
+[![skills.sh](https://skills.sh/b/TurboDocx/quickstart)](https://skills.sh/TurboDocx/quickstart)
+
+Skip the boilerplate. If you use Claude Code, GitHub Copilot, Cursor, OpenAI Codex CLI, or Gemini CLI, you can install the `turbodocx-html-to-docx` [Agent Skill](https://agentskills.io) and have your AI agent install the package, detect your framework, and generate working integration code in one step:
+
+```bash
+npx skills add TurboDocx/quickstart --skill turbodocx-html-to-docx
+```
+
+Then in your editor, invoke the skill:
+
+```
+/turbodocx-html-to-docx
+```
+
+The skill will:
+1. Install `@turbodocx/html-to-docx` and any required peer dependencies
+2. Detect your project structure (Express, Next.js, Fastify, NestJS, plain Node.js, etc.)
+3. Generate a helper module and a framework-appropriate route/handler that returns a `.docx` response
+4. Add example usage that matches your existing code patterns
+
+Source for the skill lives at [TurboDocx/quickstart](https://github.com/TurboDocx/quickstart).
+
 ### TypeScript Support
 
 This package includes TypeScript typings. No additional installation is required to use it with TypeScript projects.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Based on the original work and assisted by the original contributors of [private
 Skip the boilerplate. If you use Claude Code, GitHub Copilot, Cursor, OpenCode, OpenAI Codex CLI, or Gemini CLI, you can install the `turbodocx-html-to-docx` [Agent Skill](https://agentskills.io) and have your AI agent install the package, detect your framework, and generate working integration code in one step:
 
 ```bash
-npx skills add TurboDocx/quickstart --skill turbodocx-html-to-docx
+npx skills add TurboDocx/quickstart
 ```
 
 Then in your editor, invoke the skill:

--- a/README.md
+++ b/README.md
@@ -42,15 +42,7 @@ Based on the original work and assisted by the original contributors of [private
 
 🛠️ **Developer Experience** - Full TypeScript support, comprehensive documentation, and extensive examples to get you up and running in minutes.
 
-## Installation
-
-Use the npm to install the project.
-
-```bash
-npm install @turbodocx/html-to-docx
-```
-
-### Install via Agent Skill (AI-assisted setup)
+## Install via AI Agent Skill
 
 Skip the boilerplate. If you use Claude Code, GitHub Copilot, Cursor, OpenCode, OpenAI Codex CLI, or Gemini CLI, you can install the `turbodocx-html-to-docx` [Agent Skill](https://agentskills.io) and have your AI agent install the package, detect your framework, and generate working integration code in one step:
 
@@ -71,6 +63,14 @@ The skill will:
 4. Add example usage that matches your existing code patterns
 
 Source for the skill lives at [TurboDocx/quickstart](https://github.com/TurboDocx/quickstart).
+
+## Installation
+
+Use the npm to install the project.
+
+```bash
+npm install @turbodocx/html-to-docx
+```
 
 ### TypeScript Support
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install @turbodocx/html-to-docx
 
 [![skills.sh](https://skills.sh/b/TurboDocx/quickstart)](https://skills.sh/TurboDocx/quickstart)
 
-Skip the boilerplate. If you use Claude Code, GitHub Copilot, Cursor, OpenAI Codex CLI, or Gemini CLI, you can install the `turbodocx-html-to-docx` [Agent Skill](https://agentskills.io) and have your AI agent install the package, detect your framework, and generate working integration code in one step:
+Skip the boilerplate. If you use Claude Code, GitHub Copilot, Cursor, OpenCode, OpenAI Codex CLI, or Gemini CLI, you can install the `turbodocx-html-to-docx` [Agent Skill](https://agentskills.io) and have your AI agent install the package, detect your framework, and generate working integration code in one step:
 
 ```bash
 npx skills add TurboDocx/quickstart --skill turbodocx-html-to-docx

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Type Script](https://shields.io/badge/TypeScript-3178C6?logo=TypeScript&logoColor=FFF&style=flat-square)](https://typescript.org)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord)](https://discord.gg/NYKwz4BcpX)
 [![npm](https://img.shields.io/npm/dm/@turbodocx/html-to-docx)](https://www.npmjs.com/package/@turbodocx/html-to-docx)
+[![Agent Skill](https://img.shields.io/badge/agent_skill-agentskills.io-7C3AED)](https://agentskills.io)
 [![X](https://img.shields.io/badge/X-@TurboDocx-1DA1F2?logo=x&logoColor=white)](https://twitter.com/TurboDocx)
 [![Embed TurboDocx in Your App in Minutes](https://img.shields.io/badge/Embed%20TurboDocx%20in%20Your%20App%20in%20Minutes-8A2BE2)](https://www.turbodocx.com/use-cases/embedded-api?utm_source=github&utm_medium=repo&utm_campaign=open_source)
 


### PR DESCRIPTION
## Summary
- Adds an **Install via Agent Skill** section in the README right under the standard `npm install`.
- Points users at `npx skills add TurboDocx/quickstart --skill turbodocx-html-to-docx` — works with Claude Code, Copilot, Cursor, Codex CLI, and Gemini CLI.
- The skill auto-detects the user's framework (Express, Next.js, Fastify, NestJS, plain Node) and generates a helper module + route handler so first-time users go from zero to a working `.docx` response without copying boilerplate.
- Includes a [skills.sh](https://skills.sh/TurboDocx/quickstart) badge.

Skill source lives at [TurboDocx/quickstart](https://github.com/TurboDocx/quickstart) (the `turbodocx-html-to-docx` skill).

## Test plan
- [ ] Render the README on GitHub and confirm the new section appears between `## Installation` and `### TypeScript Support`
- [ ] Confirm the skills.sh badge image loads and links to the registry
- [ ] Run `npx skills add TurboDocx/quickstart --skill turbodocx-html-to-docx` in a fresh project and verify the skill installs and `/turbodocx-html-to-docx` generates a working integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)