### PR TITLE
docs: add Agent Skill install path to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Based on the original work and assisted by the original contributors of [private
 Skip the boilerplate. If you use Claude Code, GitHub Copilot, Cursor, OpenCode, OpenAI Codex CLI, or Gemini CLI, you can install the `turbodocx-html-to-docx` [Agent Skill](https://agentskills.io) and have your AI agent install the package, detect your framework, and generate working integration code in one step:
 
 ```bash
-npx skills add TurboDocx/quickstart --skill turbodocx-html-to-docx
+npx skills add TurboDocx/quickstart
 ```
 
 Then in your editor, invoke the skill:

--- a/README.md
+++ b/README.md
@@ -42,15 +42,7 @@ Based on the original work and assisted by the original contributors of [private
 
 🛠️ **Developer Experience** - Full TypeScript support, comprehensive documentation, and extensive examples to get you up and running in minutes.
 
-## Installation
-
-Use the npm to install the project.
-
-```bash
-npm install @turbodocx/html-to-docx
-```
-
-### Install via Agent Skill (AI-assisted setup)
+## Install via AI Agent Skill
 
 Skip the boilerplate. If you use Claude Code, GitHub Copilot, Cursor, OpenCode, OpenAI Codex CLI, or Gemini CLI, you can install the `turbodocx-html-to-docx` [Agent Skill](https://agentskills.io) and have your AI agent install the package, detect your framework, and generate working integration code in one step:
 
@@ -71,6 +63,14 @@ The skill will:
 4. Add example usage that matches your existing code patterns
 
 Source for the skill lives at [TurboDocx/quickstart](https://github.com/TurboDocx/quickstart).
+
+## Installation
+
+Use the npm to install the project.
+
+```bash
+npm install @turbodocx/html-to-docx
+```
 
 ### TypeScript Support
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ Use the npm to install the project.
 npm install @turbodocx/html-to-docx
 ```
 
+### Install via Agent Skill (AI-assisted setup)
+
+Skip the boilerplate. If you use Claude Code, GitHub Copilot, Cursor, OpenCode, OpenAI Codex CLI, or Gemini CLI, you can install the `turbodocx-html-to-docx` [Agent Skill](https://agentskills.io) and have your AI agent install the package, detect your framework, and generate working integration code in one step:
+
+```bash
+npx skills add TurboDocx/quickstart --skill turbodocx-html-to-docx
+```
+
+Then in your editor, invoke the skill:
+
+```
+/turbodocx-html-to-docx
+```
+
+The skill will:
+1. Install `@turbodocx/html-to-docx` and any required peer dependencies
+2. Detect your project structure (Express, Next.js, Fastify, NestJS, plain Node.js, etc.)
+3. Generate a helper module and a framework-appropriate route/handler that returns a `.docx` response
+4. Add example usage that matches your existing code patterns
+
+Source for the skill lives at [TurboDocx/quickstart](https://github.com/TurboDocx/quickstart).
+
 ### TypeScript Support
 
 This package includes TypeScript typings. No additional installation is required to use it with TypeScript projects.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Type Script](https://shields.io/badge/TypeScript-3178C6?logo=TypeScript&logoColor=FFF&style=flat-square)](https://typescript.org)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord)](https://discord.gg/NYKwz4BcpX)
 [![npm](https://img.shields.io/npm/dm/@turbodocx/html-to-docx)](https://www.npmjs.com/package/@turbodocx/html-to-docx)
+[![Agent Skill](https://img.shields.io/badge/agent_skill-agentskills.io-7C3AED)](https://agentskills.io)
 [![X](https://img.shields.io/badge/X-@TurboDocx-1DA1F2?logo=x&logoColor=white)](https://twitter.com/TurboDocx)
 [![Embed TurboDocx in Your App in Minutes](https://img.shields.io/badge/Embed%20TurboDocx%20in%20Your%20App%20in%20Minutes-8A2BE2)](https://www.turbodocx.com/use-cases/embedded-api?utm_source=github&utm_medium=repo&utm_campaign=open_source)
 


### PR DESCRIPTION
## Summary

Adds an **Install via Agent Skill** subsection under `## Installation` so developers using AI coding agents can set up `@turbodocx/html-to-docx` in a single prompt.

- Install command: `npx skills add TurboDocx/quickstart --skill turbodocx-html-to-docx`
- Works with Claude Code, GitHub Copilot, Cursor, OpenCode, OpenAI Codex CLI, Gemini CLI
- Skill source: https://github.com/TurboDocx/quickstart

See also: PR #195 (same change targeting `develop`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)