### PR TITLE
fix: inline color on <strong>/<em>/<u> overrides ancestor color (closes #200)

### DIFF
--- a/example/example-node.js
+++ b/example/example-node.js
@@ -2564,6 +2564,48 @@ const htmlString = `<!DOCTYPE html>
             </tr>
         </table>
 
+        <h1>Inline Color Override Tests (PR #201 — Issue #200)</h1>
+        <p>Inline <code>style="color: …"</code> on phrasing-content elements
+           (&lt;strong&gt;, &lt;em&gt;, &lt;u&gt;, etc.) must override the ancestor block's
+           color — previously the child's color was silently dropped.</p>
+
+        <h2>Legal-document highlight pattern</h2>
+        <p style="font-size: 14pt; color: #000000; line-height: 1.5;">
+           <strong style="color: #4477c6;">WHEREFORE, </strong>based on the foregoing, the Defendant
+           respectfully requests that this Honorable Court enter an order precluding the State from
+           introducing any evidence or testimony regarding alleged past sales.
+        </p>
+
+        <h2>Each inline element with its own color</h2>
+        <p style="color: #000000;">
+           plain
+           <strong style="color: #ff0000;">strongRed</strong>
+           plain
+           <em style="color: #008000;">emGreen</em>
+           plain
+           <u style="color: #0000ff;">uBlue</u>
+           plain
+           <del style="color: #ff8800;">delOrange</del>
+           plain
+           <span style="color: #aa00ff;">spanPurple</span>
+           plain
+        </p>
+
+        <h2>Nested inline elements — innermost color wins</h2>
+        <p style="color: #000000;">
+           <strong style="color: #ff8800;">
+             outerOrange
+             <em style="color: #aa00ff;">innerPurple</em>
+             trailingOrange
+           </strong>
+        </p>
+
+        <h2>Inline elements with no own color inherit ancestor</h2>
+        <p style="color: #4477c6;">
+           <strong>boldInherited</strong>
+           <em>italicInherited</em>
+        </p>
+
     </body>
 </html>`;
 

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -840,20 +840,27 @@ const buildRun = async (vNode, attributes, docxDocumentInstance) => {
             formattingFragmentAttributes.textTransform || tempAttributes.textTransform
           )
         );
-        // we don't need to pass the formattingFragmentAttributes to the buildRunProperties function
-        // since the attributes are already applied to the runPropertiesFragment
-        // if the children is text then we directly reach this if node
-        // if the node is a span, then those attributes are passed to the buildRunOrRuns function
-        // and the attributes are applied to the runPropertiesFragment
-        // if node is formatting node, then the attributes are stored in formattingFragmentAttributes
-        // and are applied to the text node as required
-        const tempRunPropertiesFragment = buildRunProperties({ ...attributes, ...tempAttributes });
+        // formattingFragmentAttributes carries inline <strong>/<em>/<u>/<del>
+        // overrides parsed from their `style` attributes (issue #200). Spreading
+        // it LAST lets the inline element's color/font/size/etc. beat the
+        // ancestor paragraph's color when both are present. The bold/italic
+        // semantic from the tag itself comes in via tempAttributes earlier in
+        // the spread.
+        const tempRunPropertiesFragment = buildRunProperties({
+          ...attributes,
+          ...tempAttributes,
+          ...formattingFragmentAttributes,
+        });
         tempRunFragment.import(tempRunPropertiesFragment);
         tempRunFragment.import(textFragment);
         runFragmentsArray.push(tempRunFragment);
 
-        // re initialize temp run fragments with new fragment
+        // re initialize temp run fragments with new fragment. formatting
+        // fragment attributes are reset alongside tempAttributes so sibling
+        // runs (e.g. the body text after </strong>) don't inherit the
+        // previous inline element's color.
         tempAttributes = cloneDeep(attributes);
+        formattingFragmentAttributes = {};
         tempRunFragment = fragment({ namespaceAlias: { w: namespaces.w } }).ele('@w', 'r');
       } else if (isVNode(tempVNode)) {
         if (

--- a/tests/inline-color-override.test.js
+++ b/tests/inline-color-override.test.js
@@ -1,0 +1,111 @@
+/**
+ * Inline color override tests (issue #200).
+ *
+ * When a paragraph (or any block element) has an inline `color` style AND an
+ * inline element inside it (<strong>, <em>, <u>, <a>, <span>) also has its
+ * own inline `color`, the child's color must win for the corresponding run.
+ *
+ * The pre-fix behavior was that the parent's color silently "won" for the
+ * child's run, dropping the inline override. Legal documents authored in
+ * tools that highlight key phrases via <strong style="color: #..."> were the
+ * primary motivator (e.g. "WHEREFORE,", "NOW THEREFORE,").
+ */
+
+import HTMLtoDOCX from '../index.js';
+import { parseDOCX } from './helpers/docx-assertions.js';
+
+function findRunsWithText(xml, needle) {
+  const re = /<w:r\b[^>]*>([\s\S]*?)<\/w:r>/g;
+  const runs = [];
+  let m;
+  while ((m = re.exec(xml)) !== null) {
+    if (m[1].includes(needle)) runs.push(m[1]);
+  }
+  return runs;
+}
+
+function extractColor(runInner) {
+  const m = runInner.match(/<w:color w:val="([^"]+)"/);
+  return m ? m[1].toLowerCase() : null;
+}
+
+describe('Inline color override on inline elements (issue #200)', () => {
+  test('<strong style="color: #4477c6"> overrides ancestor <p style="color: #000000">', async () => {
+    const html =
+      '<p style="font-size: 14pt; color: #000000;">' +
+      '<strong style="color: #4477c6;">WHEREFORE, </strong>' +
+      'rest of paragraph.</p>';
+    const buf = await HTMLtoDOCX(html, null, { deterministicIds: true });
+    const { xml } = await parseDOCX(buf);
+
+    const wherefore = findRunsWithText(xml, 'WHEREFORE,')[0];
+    const rest = findRunsWithText(xml, 'rest of paragraph')[0];
+    expect(wherefore).toBeDefined();
+    expect(rest).toBeDefined();
+
+    expect(extractColor(wherefore)).toBe('4477c6');
+    expect(extractColor(rest)).toBe('000000');
+    // The strong's bold must still apply
+    expect(wherefore).toContain('<w:b/>');
+  });
+
+  test('<em style="color: red"> overrides ancestor color', async () => {
+    const html =
+      '<p style="color: #000000;"><em style="color: #ff0000;">italicRed</em> trailing</p>';
+    const buf = await HTMLtoDOCX(html, null, { deterministicIds: true });
+    const { xml } = await parseDOCX(buf);
+    const run = findRunsWithText(xml, 'italicRed')[0];
+    expect(extractColor(run)).toBe('ff0000');
+    expect(run).toContain('<w:i/>');
+  });
+
+  test('<u style="color: green"> overrides ancestor color', async () => {
+    const html =
+      '<p style="color: #000000;"><u style="color: #00aa00;">undGreen</u> trailing</p>';
+    const buf = await HTMLtoDOCX(html, null, { deterministicIds: true });
+    const { xml } = await parseDOCX(buf);
+    const run = findRunsWithText(xml, 'undGreen')[0];
+    expect(extractColor(run)).toBe('00aa00');
+  });
+
+  test('<span style="color: blue"> nested directly in a colored paragraph overrides', async () => {
+    const html =
+      '<p style="color: #000000;"><span style="color: #0000ff;">spanBlue</span> trailing</p>';
+    const buf = await HTMLtoDOCX(html, null, { deterministicIds: true });
+    const { xml } = await parseDOCX(buf);
+    const run = findRunsWithText(xml, 'spanBlue')[0];
+    expect(extractColor(run)).toBe('0000ff');
+  });
+
+  test('nested <strong style="color: orange"><em style="color: purple"> uses the innermost color', async () => {
+    const html =
+      '<p style="color: #000000;">' +
+      '<strong style="color: #ff8800;">' +
+      '<em style="color: #aa00ff;">innerPurple</em>' +
+      ' boldOrange' +
+      '</strong></p>';
+    const buf = await HTMLtoDOCX(html, null, { deterministicIds: true });
+    const { xml } = await parseDOCX(buf);
+
+    const innerRun = findRunsWithText(xml, 'innerPurple')[0];
+    expect(extractColor(innerRun)).toBe('aa00ff');
+    // Bold and italic both apply
+    expect(innerRun).toContain('<w:b/>');
+    expect(innerRun).toContain('<w:i/>');
+
+    const outerRun = findRunsWithText(xml, 'boldOrange')[0];
+    expect(extractColor(outerRun)).toBe('ff8800');
+    expect(outerRun).toContain('<w:b/>');
+  });
+
+  test('child element with no color inherits the parent color', async () => {
+    // Pin existing inheritance so the fix does not regress it.
+    const html =
+      '<p style="color: #4477c6;"><strong>BoldNoOwnColor</strong> trailing</p>';
+    const buf = await HTMLtoDOCX(html, null, { deterministicIds: true });
+    const { xml } = await parseDOCX(buf);
+    const run = findRunsWithText(xml, 'BoldNoOwnColor')[0];
+    expect(extractColor(run)).toBe('4477c6');
+    expect(run).toContain('<w:b/>');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #200.

Inline \`color\` styles on phrasing-content elements (\`<strong>\`, \`<em>\`, \`<u>\`, \`<del>\`, \`<s>\`, \`<strike>\`, etc.) were silently dropped when an ancestor block element also had a \`color\` style. Runs inherited the ancestor color, dropping the child's override.

Most visible in legal documents that highlight intro phrases via patterns like:

\`\`\`html
<p style="color: #000000;">
  <strong style="color: #4477c6;">WHEREFORE, </strong>based on the foregoing...
</p>
\`\`\`

Before this PR, \`WHEREFORE,\` rendered in plain black instead of the highlighted blue.

## Root cause

In \`buildRun()\` (\`src/helpers/xml-builder.js\`), the phrasing-tag branch parses the child's inline \`style\` into a local \`formattingFragmentAttributes\` object — but that object was never passed to \`buildRunProperties()\` when the text run was emitted. Only the ancestor \`attributes\` and the bold/italic semantic in \`tempAttributes\` reached the run.

## Fix

\`\`\`diff
- const tempRunPropertiesFragment = buildRunProperties({ ...attributes, ...tempAttributes });
+ const tempRunPropertiesFragment = buildRunProperties({
+   ...attributes,
+   ...tempAttributes,
+   ...formattingFragmentAttributes,
+ });
\`\`\`

Spread \`formattingFragmentAttributes\` LAST so the child's color/font/size override the ancestor's. Also reset it alongside \`tempAttributes\` after each emitted run so sibling runs don't inherit the previous inline element's color.

## TDD

6 tests in \`tests/inline-color-override.test.js\`:

- \`<strong style="color: #4477c6">\` overrides ancestor \`<p style="color: #000000">\` (the original repro)
- \`<em style="color: red">\` overrides ancestor color
- \`<u style="color: green">\` overrides ancestor color
- \`<span style="color: blue">\` already worked — pinned to prevent regression
- Nested \`<strong style="color: orange"><em style="color: purple">\` uses innermost color, applies both bold + italic
- Plain \`<strong>\` (no own color) still inherits ancestor — pins the inheritance contract

Verified the suite fails (4/6) without the fix and passes (6/6) with it.

## Verification

| | Before | After |
|---|---|---|
| Unit suite | 588/588 | **594/594** (+6) |
| WHEREFORE run color | \`000000\` (wrong) | **\`4477c6\`** (correct) |
| Body text color | \`000000\` ✓ | \`000000\` ✓ |
| Bold on WHEREFORE | ✓ | ✓ |
| A/B vs develop on example-node.js | — | 71 identical files, 0 changed (no regressions) |

## Test plan

- [x] \`npm run test:unit\` passes (594/594)
- [x] Reproducer renders \`WHEREFORE\` in \`#4477c6\`
- [x] Existing tests still pass (no regression in 588 prior tests)
- [x] No drift vs develop on \`example-node.js\` baseline