### PR TITLE
feat: CSS stylesheet support via documentOptions.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ full fledged examples can be found under `example/`
     - `keepNext` <?[Boolean]> keep with next paragraph. Defaults to `true`
     - `outlineLevel` <?[Number]> outline level (0-5)
   - `decodeUnicode` <?[Boolean]> flag to enable unicode decoding of header, body and footer. Defaults to `false`.
+  - `css` <?[String]> a CSS stylesheet applied to the content, header, and footer HTML. Selectors (type, class, id, descendant, grouped, etc.) are resolved with standard specificity and folded into each element's style; an element's own inline `style` always wins. Embedded `<style>` tags in the HTML are honored too. See [CSS Stylesheet Support](#css-stylesheet-support). Defaults to `null`.
   - `lang` <?[String]> language localization code for spell checker to work properly. Defaults to `en-US`.
   - `direction` <?[String]> text direction for RTL (right-to-left) languages. Set to `'rtl'` for Arabic, Hebrew, etc. Defaults to `'ltr'`.
   - `preProcessing` <?[Object]>
@@ -429,6 +430,56 @@ full fledged examples can be found under `example/`
 ### Returns
 
 <[Promise]<[Buffer]|[Blob]>>
+
+## CSS Stylesheet Support
+
+Instead of putting a `style="..."` attribute on every element, you can attach a
+CSS stylesheet via the `css` document option. Selectors are matched against your
+HTML and resolved into the document, so you can style by tag, class, or id and
+keep your markup clean.
+
+```js
+const HTMLtoDOCX = require('@turbodocx/html-to-docx');
+
+const html = `
+  <h1 class="title">Quarterly Report</h1>
+  <p class="lead">Styled entirely from the stylesheet.</p>
+  <p>A regular paragraph.</p>
+  <p class="lead" style="color: #006600;">Inline color wins here.</p>
+`;
+
+const css = `
+  h1, h2        { text-align: center; }
+  .title        { color: #1a3c7a; font-size: 28pt; }
+  p             { color: #222222; font-size: 12pt; }
+  .lead         { color: #1a73e8; font-size: 14pt; }
+`;
+
+const buffer = await HTMLtoDOCX(html, null, { css });
+```
+
+How it resolves:
+
+- **Selectors:** type (`p`), class (`.lead`), id (`#intro`), descendant
+  (`div span`), and grouped (`h1, h2`) selectors are supported.
+- **Specificity & cascade:** rules are applied by standard CSS specificity
+  (id > class/attribute > type), with source order breaking ties.
+- **Inline wins:** an element's own inline `style` attribute always overrides a
+  matching stylesheet rule, so existing inline styles keep working unchanged.
+- **Embedded `<style>` tags:** `<style>` blocks inside your HTML are honored and
+  removed from the output, so their CSS text never renders as document content.
+- **Applies everywhere:** the stylesheet is applied to the content, header, and
+  footer HTML.
+- **Supported properties:** any CSS property this library already understands
+  from inline styles (color, `text-align`, `font-size`, `font-family`,
+  width/height, borders, background, text-decoration, and so on). Properties the
+  library does not consume are ignored.
+
+Not supported in this version: `!important`, at-rules such as `@media` and
+`@font-face`, and external `<link rel="stylesheet">` files (pass the CSS text
+via the `css` option instead).
+
+A runnable example lives in [`example/example-css-stylesheet.js`](example/example-css-stylesheet.js).
 
 ## Notes
 

--- a/example/example-css-stylesheet.js
+++ b/example/example-css-stylesheet.js
@@ -1,0 +1,102 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+// FIXME: Incase you have the npm package
+// const HTMLtoDOCX = require('@turbodocx/html-to-docx');
+const HTMLtoDOCX = require('../dist/html-to-docx.umd');
+
+const filePath = './example-css-stylesheet.docx';
+
+// The HTML carries NO inline styles of its own (except one, to show that inline
+// styles always win). All of the look-and-feel comes from the stylesheet below.
+const htmlString = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>CSS Stylesheet Example</title>
+  <!-- Embedded <style> tags are honored too and are stripped from the output -->
+  <style>
+    .callout { color: #b30000; }
+  </style>
+</head>
+<body>
+  <h1 class="title">Quarterly Business Review</h1>
+  <h2 id="subtitle">Q2 2026 — Confidential</h2>
+
+  <p class="lead">This summary is styled entirely from an attached stylesheet.</p>
+
+  <p>Regular body paragraph. Type selectors style every paragraph at once.</p>
+
+  <p class="callout">Callout text colored by an embedded &lt;style&gt; tag.</p>
+
+  <p class="lead" style="color: #006600;">
+    This paragraph is <code>.lead</code> (blue) but has an inline green color —
+    inline always wins, so it renders green.
+  </p>
+
+  <blockquote class="quote">
+    "Selectors, specificity, and the cascade all work as you would expect."
+  </blockquote>
+
+  <table class="data">
+    <tr><th>Region</th><th>Revenue</th></tr>
+    <tr><td>North</td><td>$1.2M</td></tr>
+    <tr><td>South</td><td>$0.9M</td></tr>
+  </table>
+</body>
+</html>`;
+
+// A normal CSS stylesheet: type, class, id, descendant and grouped selectors.
+const css = `
+  h1, h2 {
+    text-align: center;
+    font-family: 'Georgia';
+  }
+  .title {
+    color: #1a3c7a;
+    font-size: 28pt;
+  }
+  #subtitle {
+    color: #888888;
+    font-size: 14pt;
+  }
+  p {
+    color: #222222;
+    font-size: 12pt;
+  }
+  .lead {
+    color: #1a73e8;
+    font-size: 14pt;
+  }
+  blockquote.quote {
+    color: #555555;
+    text-align: center;
+  }
+  table.data {
+    border-collapse: collapse;
+  }
+  table.data th {
+    background-color: #1a3c7a;
+    color: #ffffff;
+    text-align: center;
+  }
+  table.data td {
+    text-align: center;
+  }
+`;
+
+(async () => {
+  const fileBuffer = await HTMLtoDOCX(htmlString, null, {
+    css,
+    table: { row: { cantSplit: true } },
+    // deterministicIds is ONLY for CI/CD testing. Do NOT use in production.
+    deterministicIds: process.env.DETERMINISTIC_IDS === 'true',
+  });
+
+  fs.writeFile(filePath, fileBuffer, (error) => {
+    if (error) {
+      console.log('Docx file creation failed');
+      return;
+    }
+    console.log('Docx file created successfully');
+  });
+})();

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,6 +90,15 @@ declare namespace HTMLtoDOCX {
         };
         heading?: HeadingConfig;
         decodeUnicode?: boolean;
+        /**
+         * A CSS stylesheet applied to the content, header, and footer HTML.
+         * Selectors (type, class, id, descendant, grouped, etc.) are resolved
+         * with standard specificity and folded into each element's inline
+         * style; an element's own inline `style` always wins. Embedded
+         * `<style>` tags in the HTML are honored too. `!important`, at-rules,
+         * and external `<link>` stylesheets are not supported.
+         */
+        css?: string;
         lang?: string;
         direction?: "ltr" | "rtl";
         preprocessing?: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
       "dependencies": {
         "axios": "^1.12.2",
         "color-name": "^1.1.4",
+        "css-select": "5.2.2",
+        "css-tree": "3.2.1",
+        "domutils": "3.2.2",
         "html-entities": "^2.3.3",
         "html-minifier-terser": "^7.2.0",
         "htmlparser2": "^10.0.0",
@@ -4882,6 +4885,12 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -5824,6 +5833,47 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/dargs": {
@@ -11217,6 +11267,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
     "node_modules/meow": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
@@ -11447,6 +11503,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-inspect": {
@@ -12806,6 +12874,15 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -160,6 +160,9 @@
   "dependencies": {
     "axios": "^1.12.2",
     "color-name": "^1.1.4",
+    "css-select": "5.2.2",
+    "css-tree": "3.2.1",
+    "domutils": "3.2.2",
     "html-entities": "^2.3.3",
     "html-minifier-terser": "^7.2.0",
     "htmlparser2": "^10.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,21 @@ const banner = `// ${meta.homepage} v${meta.version} Copyright ${new Date().getF
 // Node.js / Library build configuration (ESM and UMD)
 const libraryConfig = {
   input: 'index.js',
-  external: ['color-name', 'jszip', 'xmlbuilder2', 'html-entities', 'lru-cache', 'htmlparser2', 'sharp'],
+  external: [
+    'color-name',
+    'jszip',
+    'xmlbuilder2',
+    'html-entities',
+    'lru-cache',
+    'htmlparser2',
+    'sharp',
+    // CSS stylesheet resolver deps. Externalized (like htmlparser2 et al.) so
+    // they are required from node_modules at runtime — css-tree loads JSON data
+    // files (data/patch.json, mdn-data) that cannot be inlined into the bundle.
+    'css-select',
+    'css-tree',
+    'domutils',
+  ],
   plugins: [
     resolve(),
     json(),
@@ -45,6 +59,9 @@ const libraryConfig = {
         jszip: 'JSZip',
         xmlbuilder2: 'xmlbuilder2',
         'html-entities': 'htmlEntities',
+        'css-select': 'cssSelect',
+        'css-tree': 'csstree',
+        domutils: 'domutils',
       },
       banner,
     },

--- a/src/docx-document.js
+++ b/src/docx-document.js
@@ -140,6 +140,7 @@ class DocxDocument {
   constructor(properties) {
     this.zip = properties.zip;
     this.htmlString = properties.htmlString;
+    this.css = properties.css || null;
     this.orientation = properties.orientation;
     this.pageSize = properties.pageSize || defaultDocumentOptions.pageSize;
     this.deterministicIds = properties.deterministicIds || false;

--- a/src/helpers/css-resolver.js
+++ b/src/helpers/css-resolver.js
@@ -1,0 +1,235 @@
+/* eslint-disable no-continue, no-restricted-syntax */
+/**
+ * CSS Stylesheet Resolver
+ *
+ * Folds a CSS stylesheet into each matched element's inline `style` attribute
+ * BEFORE the HTML is converted to the virtual DOM. The rest of the pipeline
+ * (xml-builder) reads styling exclusively from each element's parsed inline
+ * `style`, so resolving the stylesheet here lets every CSS property the library
+ * already understands work from a stylesheet too, with no downstream changes.
+ *
+ * CSS comes from two sources:
+ *   1. `documentOptions.css` (an attached stylesheet string)
+ *   2. embedded `<style>` tags in the HTML (extracted and removed so their raw
+ *      text is never rendered as document content)
+ *
+ * The cascade is resolved by real selector specificity (id > class/attr/pseudo
+ * > type) with source order breaking ties. The element's own inline declaration
+ * always wins because it is concatenated LAST onto the `style` string and
+ * `parseStyles` (in html-parser.js) is last-write-wins.
+ *
+ * `!important`, `@media`/at-rules, and `<link>` fetching are intentionally out
+ * of scope for this version.
+ */
+
+import { selectAll } from 'css-select';
+import * as csstree from 'css-tree';
+import { removeElement, textContent } from 'domutils';
+
+/**
+ * Compute the specificity of a single css-tree Selector node as an
+ * [a, b, c] tuple where:
+ *   a = number of id selectors
+ *   b = number of class, attribute, and pseudo-class selectors
+ *   c = number of type and pseudo-element selectors (universal `*` excluded)
+ *
+ * @param {Object} selectorNode - a css-tree `Selector` AST node
+ * @returns {number[]} `[a, b, c]`
+ */
+function computeSpecificity(selectorNode) {
+  const specificity = [0, 0, 0];
+
+  csstree.walk(selectorNode, (node) => {
+    switch (node.type) {
+      case 'IdSelector':
+        specificity[0] += 1;
+        break;
+      case 'ClassSelector':
+      case 'AttributeSelector':
+      case 'PseudoClassSelector':
+        specificity[1] += 1;
+        break;
+      case 'TypeSelector':
+        if (node.name !== '*') specificity[2] += 1;
+        break;
+      case 'PseudoElementSelector':
+        specificity[2] += 1;
+        break;
+      default:
+        break;
+    }
+  });
+
+  return specificity;
+}
+
+/** Compare two `[a, b, c]` specificity tuples. Returns <0, 0, or >0. */
+function compareSpecificity(left, right) {
+  for (let i = 0; i < 3; i += 1) {
+    if (left[i] !== right[i]) return left[i] - right[i];
+  }
+  return 0;
+}
+
+/**
+ * Serialize a css-tree Block (declaration list) into a normalized
+ * `prop: value; prop: value;` string. `!important` is ignored (the declaration
+ * is kept, its importance is not).
+ *
+ * @param {Object} blockNode - a css-tree `Block` AST node
+ * @returns {string}
+ */
+function serializeDeclarations(blockNode) {
+  const parts = [];
+
+  if (blockNode && blockNode.children) {
+    blockNode.children.forEach((declaration) => {
+      if (declaration.type !== 'Declaration') return;
+      const value = csstree.generate(declaration.value).trim();
+      if (declaration.property && value) {
+        parts.push(`${declaration.property}: ${value}`);
+      }
+    });
+  }
+
+  return parts.join('; ');
+}
+
+/**
+ * Extract the CSS text from every `<style>` element in the DOM and remove those
+ * elements so their contents do not leak into the rendered document.
+ *
+ * @param {Object} params
+ * @param {(Object|Object[])} params.dom - htmlparser2/domhandler DOM (node or node array)
+ * @returns {string} concatenated CSS text from all `<style>` tags (in document order)
+ */
+export function extractAndStripStyleTags({ dom }) {
+  let styleNodes;
+  try {
+    styleNodes = selectAll('style', dom);
+  } catch (error) {
+    return '';
+  }
+
+  const cssChunks = styleNodes.map((node) => textContent(node));
+  styleNodes.forEach((node) => removeElement(node));
+
+  return cssChunks.join('\n');
+}
+
+/**
+ * Parse a stylesheet into a flat, ordered list of rules.
+ * Malformed CSS is tolerated: parse errors are swallowed and only the rules
+ * that parsed successfully are returned.
+ *
+ * @param {string} cssText
+ * @returns {{selectors: {text: string, specificity: number[]}[], declarations: string, order: number}[]}
+ */
+function collectRules(cssText) {
+  let ast;
+  try {
+    ast = csstree.parse(cssText, { onParseError: () => {} });
+  } catch (error) {
+    return [];
+  }
+
+  const rules = [];
+  let order = 0;
+
+  csstree.walk(ast, {
+    visit: 'Rule',
+    enter(rule) {
+      // Only plain style rules (a SelectorList prelude). Skip at-rules etc.
+      if (!rule.prelude || rule.prelude.type !== 'SelectorList') return;
+
+      const declarations = serializeDeclarations(rule.block);
+      if (!declarations) return;
+
+      const selectors = [];
+      rule.prelude.children.forEach((selectorNode) => {
+        let text;
+        try {
+          text = csstree.generate(selectorNode);
+        } catch (error) {
+          return;
+        }
+        selectors.push({ text, specificity: computeSpecificity(selectorNode) });
+      });
+
+      if (selectors.length) {
+        rules.push({ selectors, declarations, order });
+        order += 1;
+      }
+    },
+  });
+
+  return rules;
+}
+
+/**
+ * Apply a CSS stylesheet to an htmlparser2 DOM by folding matched declarations
+ * into each element's inline `style` attribute. Mutates the DOM in place.
+ *
+ * CSS is taken from `css` (attached stylesheet) and from embedded `<style>`
+ * tags in the DOM. The attached stylesheet is treated as appearing BEFORE the
+ * embedded `<style>` tags, so embedded rules win ties by source order.
+ *
+ * @param {Object} params
+ * @param {(Object|Object[])} params.dom - htmlparser2/domhandler DOM (node or node array)
+ * @param {string} [params.css] - attached stylesheet text
+ * @param {Function} [params.logger] - optional `(message) => void` for skipped selectors
+ * @returns {void}
+ */
+export function applyStylesheet({ dom, css = '', logger } = {}) {
+  if (!dom) return;
+
+  const embeddedCss = extractAndStripStyleTags({ dom });
+  const combinedCss = [css || '', embeddedCss].filter(Boolean).join('\n');
+  if (!combinedCss.trim()) return;
+
+  const rules = collectRules(combinedCss);
+  if (!rules.length) return;
+
+  // Map from element node -> list of matched declaration sets.
+  const matchesByElement = new Map();
+
+  rules.forEach((rule) => {
+    rule.selectors.forEach((selector) => {
+      let elements;
+      try {
+        elements = selectAll(selector.text, dom);
+      } catch (error) {
+        if (typeof logger === 'function') {
+          logger(`[css] skipping unsupported selector "${selector.text}": ${error.message}`);
+        }
+        return;
+      }
+
+      elements.forEach((element) => {
+        if (!matchesByElement.has(element)) matchesByElement.set(element, []);
+        matchesByElement.get(element).push({
+          specificity: selector.specificity,
+          order: rule.order,
+          declarations: rule.declarations,
+        });
+      });
+    });
+  });
+
+  matchesByElement.forEach((entries, element) => {
+    entries.sort((left, right) => {
+      const bySpecificity = compareSpecificity(left.specificity, right.specificity);
+      if (bySpecificity !== 0) return bySpecificity;
+      return left.order - right.order;
+    });
+
+    const stylesheetStyle = entries.map((entry) => entry.declarations).join('; ');
+    const inlineStyle = (element.attribs && element.attribs.style) || '';
+
+    // Inline declarations come LAST so they win (parseStyles is last-write-wins).
+    const combined = [stylesheetStyle, inlineStyle.trim()].filter(Boolean).join('; ');
+
+    if (!element.attribs) element.attribs = {};
+    element.attribs.style = combined;
+  });
+}

--- a/src/helpers/css-resolver.js
+++ b/src/helpers/css-resolver.js
@@ -39,26 +39,33 @@ import { removeElement, textContent } from 'domutils';
 function computeSpecificity(selectorNode) {
   const specificity = [0, 0, 0];
 
-  csstree.walk(selectorNode, (node) => {
-    switch (node.type) {
-      case 'IdSelector':
-        specificity[0] += 1;
-        break;
-      case 'ClassSelector':
-      case 'AttributeSelector':
-      case 'PseudoClassSelector':
-        specificity[1] += 1;
-        break;
-      case 'TypeSelector':
-        if (node.name !== '*') specificity[2] += 1;
-        break;
-      case 'PseudoElementSelector':
-        specificity[2] += 1;
-        break;
-      default:
-        break;
-    }
-  });
+  // Iterate the selector's direct components only. Deliberately NOT a deep walk:
+  // descending into a functional pseudo-class argument (e.g. `:where(p)`,
+  // `:not(.x)`) would double-count the inner selector and inflate specificity.
+  // Each compound part and combinator of a complex selector is a direct child
+  // of the Selector node, so one level covers `div .a#b` correctly.
+  if (selectorNode.children) {
+    selectorNode.children.forEach((node) => {
+      switch (node.type) {
+        case 'IdSelector':
+          specificity[0] += 1;
+          break;
+        case 'ClassSelector':
+        case 'AttributeSelector':
+        case 'PseudoClassSelector':
+          specificity[1] += 1;
+          break;
+        case 'TypeSelector':
+          if (node.name !== '*') specificity[2] += 1;
+          break;
+        case 'PseudoElementSelector':
+          specificity[2] += 1;
+          break;
+        default:
+          break;
+      }
+    });
+  }
 
   return specificity;
 }
@@ -136,31 +143,34 @@ function collectRules(cssText) {
   const rules = [];
   let order = 0;
 
-  csstree.walk(ast, {
-    visit: 'Rule',
-    enter(rule) {
-      // Only plain style rules (a SelectorList prelude). Skip at-rules etc.
-      if (!rule.prelude || rule.prelude.type !== 'SelectorList') return;
+  // Iterate only the stylesheet's TOP-LEVEL rules. We intentionally do not walk
+  // into at-rules: a rule nested in `@media`, `@supports`, `@container`, etc. is
+  // conditional, so applying it unconditionally would be wrong. At-rules are
+  // documented as unsupported and are therefore ignored here.
+  if (!ast.children) return rules;
 
-      const declarations = serializeDeclarations(rule.block);
-      if (!declarations) return;
+  ast.children.forEach((node) => {
+    // Only plain style rules (a SelectorList prelude). Skip Atrule nodes etc.
+    if (node.type !== 'Rule' || !node.prelude || node.prelude.type !== 'SelectorList') return;
 
-      const selectors = [];
-      rule.prelude.children.forEach((selectorNode) => {
-        let text;
-        try {
-          text = csstree.generate(selectorNode);
-        } catch (error) {
-          return;
-        }
-        selectors.push({ text, specificity: computeSpecificity(selectorNode) });
-      });
+    const declarations = serializeDeclarations(node.block);
+    if (!declarations) return;
 
-      if (selectors.length) {
-        rules.push({ selectors, declarations, order });
-        order += 1;
+    const selectors = [];
+    node.prelude.children.forEach((selectorNode) => {
+      let text;
+      try {
+        text = csstree.generate(selectorNode);
+      } catch (error) {
+        return;
       }
-    },
+      selectors.push({ text, specificity: computeSpecificity(selectorNode) });
+    });
+
+    if (selectors.length) {
+      rules.push({ selectors, declarations, order });
+      order += 1;
+    }
   });
 
   return rules;

--- a/src/helpers/html-parser.js
+++ b/src/helpers/html-parser.js
@@ -12,6 +12,7 @@
 import * as htmlparser2 from 'htmlparser2';
 import { decode } from 'html-entities';
 import { VNode, VText } from '../vdom/index.js';
+import { applyStylesheet } from './css-resolver.js';
 
 // ============================================================================
 // Property Info System
@@ -369,6 +370,11 @@ function convertHTML(options, html) {
 
   const converter = createConverter(VNode, VText);
   const tags = parseHTML(htmlString);
+
+  // Fold any attached stylesheet (opts.css) and embedded <style> tags into each
+  // element's inline `style` before building the VDOM. Resilient by design: a
+  // malformed sheet or unsupported selector never throws.
+  applyStylesheet({ dom: tags, css: opts.css, logger: opts.cssLogger });
 
   let convertedHTML;
   if (tags.length === 0) {

--- a/src/helpers/render-document-file.js
+++ b/src/helpers/render-document-file.js
@@ -657,7 +657,7 @@ async function renderDocumentFile(docxDocumentInstance, properties = {}) {
     }
   }
 
-  const vTree = convertHTML(docxDocumentInstance.htmlString);
+  const vTree = convertHTML({ css: docxDocumentInstance.css }, docxDocumentInstance.htmlString);
 
   if (!vTree) {
     throw new Error('Failed to convert HTML to VDOM tree. No VTree generated.');

--- a/src/html-to-docx.js
+++ b/src/html-to-docx.js
@@ -62,7 +62,7 @@ async function addFilesToContainer(
   });
 
   if (docxDocument.header && headerHTMLString) {
-    const vTree = convertHTML(headerHTMLString);
+    const vTree = convertHTML({ css: docxDocument.css }, headerHTMLString);
 
     docxDocument.relationshipFilename = headerFileName;
     const { headerId, headerXML } = await docxDocument.generateHeaderXML(vTree);
@@ -83,7 +83,7 @@ async function addFilesToContainer(
     docxDocument.headerObjects.push({ headerId, relationshipId, type: docxDocument.headerType });
   }
   if (docxDocument.footer && footerHTMLString) {
-    const vTree = convertHTML(footerHTMLString);
+    const vTree = convertHTML({ css: docxDocument.css }, footerHTMLString);
 
     docxDocument.relationshipFilename = footerFileName;
     const { footerId, footerXML } = await docxDocument.generateFooterXML(vTree);

--- a/tests/css-integration.test.js
+++ b/tests/css-integration.test.js
@@ -80,6 +80,27 @@ describe('CSS stylesheet support - end to end', () => {
     expect(footerXml).toMatch(/<jc\b[^>]*val="center"/);
   });
 
+  test('richer CSS properties from a stylesheet render (font, size, background)', async () => {
+    // Guards the property list documented in the README / example.
+    const html = '<table><tr><th class="hd">Region</th></tr></table>';
+    const css = `
+      .hd {
+        font-family: 'Georgia';
+        font-size: 14pt;
+        color: #ffffff;
+        background-color: #1a3c7a;
+      }
+    `;
+
+    const buffer = await HTMLtoDOCX(html, null, { css, deterministicIds: true });
+    const { xml } = await parseDOCX(buffer);
+
+    expect(xml).toContain('Georgia'); // font-family -> w:rFonts
+    expect(xml).toMatch(/<w:sz w:val="28"/); // 14pt -> 28 half-points
+    expect(xml).toMatch(/<w:shd[^>]*w:fill="1a3c7a"/); // background-color -> w:shd
+    expect(xml).toContain('<w:color w:val="ffffff"'); // color
+  });
+
   test('no css option leaves output unchanged (backward compatible)', async () => {
     const html = '<p>Plain</p>';
     const buffer = await HTMLtoDOCX(html, null, { deterministicIds: true });

--- a/tests/css-integration.test.js
+++ b/tests/css-integration.test.js
@@ -1,0 +1,89 @@
+/**
+ * End-to-end integration tests for CSS stylesheet support.
+ *
+ * Drives the full public API (HTMLtoDOCX) with documentOptions.css and embedded
+ * <style> tags, then inspects the generated document.xml to confirm the resolved
+ * styling reached the DOCX output.
+ */
+
+import HTMLtoDOCX from '../index.js';
+import { parseDOCX, assertRunColor } from './helpers/docx-assertions.js';
+
+describe('CSS stylesheet support - end to end', () => {
+  test('documentOptions.css colors a matching paragraph run', async () => {
+    const html = '<p class="title">Quarterly Report</p>';
+    const css = '.title { color: #ff0000; }';
+
+    const buffer = await HTMLtoDOCX(html, null, { css, deterministicIds: true });
+    const parsed = await parseDOCX(buffer);
+
+    assertRunColor(parsed, 0, 'ff0000');
+  });
+
+  test('type selector from stylesheet applies text-align to a paragraph', async () => {
+    const html = '<p>Centered</p>';
+    const css = 'p { text-align: center; }';
+
+    const buffer = await HTMLtoDOCX(html, null, { css, deterministicIds: true });
+    const { xml } = await parseDOCX(buffer);
+
+    expect(xml).toContain('<w:jc w:val="center"');
+  });
+
+  test('embedded <style> tag styles the body and does not leak as text', async () => {
+    const html = '<style>p { color: #00aa00; }</style><p>Body text</p>';
+
+    const buffer = await HTMLtoDOCX(html, null, { deterministicIds: true });
+    const parsed = await parseDOCX(buffer);
+
+    assertRunColor(parsed, 0, '00aa00');
+    expect(parsed.xml).not.toContain('color: #00aa00'); // raw CSS text not rendered
+  });
+
+  test('inline style still overrides a matching stylesheet rule end to end', async () => {
+    const html = '<p style="color: #0000ff;">Inline wins</p>';
+    const css = 'p { color: #ff0000; }';
+
+    const buffer = await HTMLtoDOCX(html, null, { css, deterministicIds: true });
+    const parsed = await parseDOCX(buffer);
+
+    assertRunColor(parsed, 0, '0000ff');
+  });
+
+  test('css applies to header and footer fragments', async () => {
+    const html = '<p>Body</p>';
+    const headerHTML = '<p class="hdr">Header</p>';
+    const footerHTML = '<p class="ftr">Footer</p>';
+    // text-align is a paragraph-level property (w:jc) that renders in header and
+    // footer fragments, proving the stylesheet reaches those converters too.
+    const css = '.hdr { text-align: right; } .ftr { text-align: center; }';
+
+    const buffer = await HTMLtoDOCX(
+      html,
+      headerHTML,
+      { css, header: true, footer: true, deterministicIds: true },
+      footerHTML
+    );
+
+    // header*.xml / footer*.xml live alongside document.xml in the zip
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(buffer);
+    const names = Object.keys(zip.files);
+    const headerName = names.find((n) => /word\/header\d*\.xml$/.test(n));
+    const footerName = names.find((n) => /word\/footer\d*\.xml$/.test(n));
+    const headerXml = await zip.file(headerName).async('string');
+    const footerXml = await zip.file(footerName).async('string');
+
+    // Header/footer fragments serialize with a namespace-prefixed attribute
+    // (e.g. `ns1:val`), so match the jc value prefix-agnostically.
+    expect(headerXml).toMatch(/<jc\b[^>]*val="right"/);
+    expect(footerXml).toMatch(/<jc\b[^>]*val="center"/);
+  });
+
+  test('no css option leaves output unchanged (backward compatible)', async () => {
+    const html = '<p>Plain</p>';
+    const buffer = await HTMLtoDOCX(html, null, { deterministicIds: true });
+    const { xml } = await parseDOCX(buffer);
+    expect(xml).toContain('Plain');
+  });
+});

--- a/tests/css-resolver.test.js
+++ b/tests/css-resolver.test.js
@@ -167,6 +167,30 @@ describe('CSS resolver - robustness', () => {
     const vtree = convertHTML({ css: '' }, '<p>hi</p>');
     expect(styleOf(findNode(vtree, 'p'))).toEqual({});
   });
+
+  test('@media (and other at-rules) are ignored, not applied unconditionally', () => {
+    // at-rules are documented as unsupported -> their nested rules must NOT be
+    // baked in as always-on styles.
+    const css = '@media print { p { color: red; } }';
+    const vtree = convertHTML({ css }, '<p>x</p>');
+    expect(styleOf(findNode(vtree, 'p')).color).toBeUndefined();
+  });
+
+  test('a top-level rule still applies when an at-rule precedes it', () => {
+    const css = '@media print { p { color: red; } } p { color: blue; }';
+    const vtree = convertHTML({ css }, '<p>x</p>');
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('blue');
+  });
+});
+
+describe('CSS resolver - functional pseudo-class specificity', () => {
+  test('a functional pseudo-class argument does not inflate specificity', () => {
+    // p.a has specificity (0,1,1). :where(p) must not be counted as (0,1,1)
+    // by walking into its argument, otherwise it would tie and win on order.
+    const css = 'p.a { color: blue; } :where(p) { color: red; }';
+    const vtree = convertHTML({ css }, '<p class="a">x</p>');
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('blue');
+  });
 });
 
 describe('CSS resolver - module API (applyStylesheet / extractAndStripStyleTags)', () => {

--- a/tests/css-resolver.test.js
+++ b/tests/css-resolver.test.js
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for the CSS stylesheet resolver (css-resolver.js).
+ *
+ * The resolver folds a CSS stylesheet (passed via documentOptions.css and/or
+ * embedded <style> tags) into each matched element's inline `style` attribute
+ * BEFORE the VDOM is built. Everything downstream (xml-builder) already reads
+ * only vNode.properties.style, so resolving here is the minimal-diff path.
+ *
+ * These tests exercise the public parser contract (convertHTML) plus the
+ * resolver's cascade logic directly.
+ */
+
+import createHTMLtoVDOM from '../src/helpers/html-parser.js';
+import { applyStylesheet, extractAndStripStyleTags } from '../src/helpers/css-resolver.js';
+import { parseDocument } from 'htmlparser2';
+import { selectAll } from 'css-select';
+
+const convertHTML = createHTMLtoVDOM();
+
+/** Depth-first search for the first VNode with the given tag name. */
+function findNode(vtree, tagName) {
+  const stack = Array.isArray(vtree) ? [...vtree] : [vtree];
+  while (stack.length) {
+    const node = stack.shift();
+    if (!node) continue; // eslint-disable-line no-continue
+    if (node.tagName === tagName) return node;
+    if (node.children) stack.push(...node.children);
+  }
+  return null;
+}
+
+/** Collect every tag name present in a vtree. */
+function collectTagNames(vtree) {
+  const names = [];
+  const stack = Array.isArray(vtree) ? [...vtree] : [vtree];
+  while (stack.length) {
+    const node = stack.shift();
+    if (!node) continue; // eslint-disable-line no-continue
+    if (node.tagName) names.push(node.tagName);
+    if (node.children) stack.push(...node.children);
+  }
+  return names;
+}
+
+const styleOf = (node) => (node && node.properties && node.properties.style) || {};
+
+describe('CSS resolver - selector support via convertHTML', () => {
+  test('type selector applies to matching element', () => {
+    const vtree = convertHTML({ css: 'p { color: red; }' }, '<p>hello</p>');
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('red');
+  });
+
+  test('class selector applies to matching element', () => {
+    const vtree = convertHTML({ css: '.brand { color: blue; }' }, '<p class="brand">hi</p>');
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('blue');
+  });
+
+  test('id selector applies to matching element', () => {
+    const vtree = convertHTML({ css: '#lead { color: green; }' }, '<p id="lead">hi</p>');
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('green');
+  });
+
+  test('descendant selector applies only to nested match', () => {
+    const vtree = convertHTML(
+      { css: 'div span { color: orange; }' },
+      '<div><span>in</span></div><span>out</span>'
+    );
+    const div = findNode(vtree, 'div');
+    const innerSpan = findNode(div, 'span');
+    expect(styleOf(innerSpan).color).toBe('orange');
+  });
+
+  test('grouped selectors apply to all listed elements', () => {
+    const vtree = convertHTML(
+      { css: 'h1, h2 { text-align: center; }' },
+      '<h1>a</h1><h2>b</h2>'
+    );
+    expect(styleOf(findNode(vtree, 'h1'))['text-align']).toBe('center');
+    expect(styleOf(findNode(vtree, 'h2'))['text-align']).toBe('center');
+  });
+
+  test('no css and no <style> leaves elements untouched', () => {
+    const vtree = convertHTML({}, '<p>hi</p>');
+    expect(styleOf(findNode(vtree, 'p'))).toEqual({});
+  });
+});
+
+describe('CSS resolver - cascade and specificity', () => {
+  test('higher specificity wins regardless of source order', () => {
+    // type rule appears AFTER the class rule but is LESS specific -> class wins
+    const css = '.brand { color: red; } p { color: blue; }';
+    const vtree = convertHTML({ css }, '<p class="brand">x</p>');
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('red');
+  });
+
+  test('id beats class for the same property', () => {
+    const css = '#x { color: green; } .brand { color: red; }';
+    const vtree = convertHTML({ css }, '<p id="x" class="brand">x</p>');
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('green');
+  });
+
+  test('equal specificity resolves by later source order', () => {
+    const css = '.a { color: red; } .b { color: blue; }';
+    const vtree = convertHTML({ css }, '<p class="a b">x</p>');
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('blue');
+  });
+
+  test('inline style wins over a matching stylesheet rule', () => {
+    const css = 'p { color: red; }';
+    const vtree = convertHTML({ css }, '<p style="color: purple;">x</p>');
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('purple');
+  });
+
+  test('stylesheet fills properties the inline style does not set', () => {
+    const css = 'p { color: red; text-align: center; }';
+    const vtree = convertHTML({ css }, '<p style="color: purple;">x</p>');
+    const style = styleOf(findNode(vtree, 'p'));
+    expect(style.color).toBe('purple'); // inline wins
+    expect(style['text-align']).toBe('center'); // stylesheet fills the gap
+  });
+});
+
+describe('CSS resolver - embedded <style> tags', () => {
+  test('<style> rules are applied to the document body', () => {
+    const html = '<style>p { color: teal; }</style><p>hi</p>';
+    const vtree = convertHTML({}, html);
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('teal');
+  });
+
+  test('<style> element is stripped so its text does not leak as content', () => {
+    const html = '<style>p { color: teal; }</style><p>hi</p>';
+    const vtree = convertHTML({}, html);
+    expect(collectTagNames(vtree)).not.toContain('style');
+  });
+
+  test('attached css and <style> combine; <style> wins ties by source order', () => {
+    // attached sheet is treated as appearing BEFORE embedded <style>
+    const html = '<style>p { color: blue; }</style><p>hi</p>';
+    const vtree = convertHTML({ css: 'p { color: red; }' }, html);
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('blue');
+  });
+});
+
+describe('CSS resolver - robustness', () => {
+  test('malformed css does not throw and valid rules still apply', () => {
+    // `background` is a malformed declaration (no value); css-tree recovers at
+    // the rule boundary, so both rules must still apply.
+    const css = 'p { color: red; background } .brand { color: blue; }';
+    let vtree;
+    expect(() => {
+      vtree = convertHTML({ css }, '<p>a</p><span class="brand">b</span>');
+    }).not.toThrow();
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('red');
+    expect(styleOf(findNode(vtree, 'span')).color).toBe('blue');
+  });
+
+  test('an unparseable selector is skipped and other rules still apply', () => {
+    const css = ':::garbage { color: red; } p { color: green; }';
+    let vtree;
+    expect(() => {
+      vtree = convertHTML({ css }, '<p>a</p>');
+    }).not.toThrow();
+    expect(styleOf(findNode(vtree, 'p')).color).toBe('green');
+  });
+
+  test('empty css string is a no-op', () => {
+    const vtree = convertHTML({ css: '' }, '<p>hi</p>');
+    expect(styleOf(findNode(vtree, 'p'))).toEqual({});
+  });
+});
+
+describe('CSS resolver - module API (applyStylesheet / extractAndStripStyleTags)', () => {
+  test('applyStylesheet mutates matched node style attribute', () => {
+    const dom = parseDocument('<p class="brand">hi</p>');
+    applyStylesheet({ dom, css: '.brand { color: red; }' });
+    const [p] = selectAll('p', dom);
+    expect(p.attribs.style).toContain('color: red');
+  });
+
+  test('extractAndStripStyleTags returns css text and removes the node', () => {
+    const dom = parseDocument('<style>p{color:red}</style><p>hi</p>');
+    const css = extractAndStripStyleTags({ dom });
+    expect(css).toContain('color:red');
+    expect(selectAll('style', dom)).toHaveLength(0);
+  });
+});

--- a/tests/html-parser.test.js
+++ b/tests/html-parser.test.js
@@ -371,10 +371,13 @@ describe('HTML Parser - Edge Cases', () => {
     expect(result.tagName).toBe('script');
   });
 
-  test('should handle style tags', () => {
+  test('should consume <style> tags as CSS instead of emitting them as nodes', () => {
+    // <style> tags are now extracted by the CSS resolver and removed from the
+    // tree so their raw text never renders as document content.
     const result = convertHTML('<style>.test { color: red; }</style>');
 
-    expect(result.tagName).toBe('style');
+    expect(isVText(result)).toBe(true);
+    expect(result.tagName).toBeUndefined();
   });
 
   test('should preserve case in attribute names', () => {


### PR DESCRIPTION
## Summary

Adds CSS stylesheet support via a new `documentOptions.css` option. Instead of putting `style="..."` on every element, callers can attach a stylesheet and style by tag, class, or id. Embedded `<style>` tags in the HTML are honored too.

```js
const css = `
  h1, h2 { text-align: center; }
  .title { color: #1a3c7a; font-size: 28pt; }
  p      { color: #222222; }
`;
const buffer = await HTMLtoDOCX(html, null, { css });
```

## How it works (minimal-diff, scalable)

The whole `xml-builder` pipeline reads styling only from each element's parsed inline `style`. So the stylesheet is resolved into each element's inline `style` **before** the VDOM is built — every CSS property the renderer already understands (color, `text-align`, `font-size`, `font-family`, width/height, borders, background, text-decoration, …) works from a stylesheet with **zero downstream changes**.

- New module `src/helpers/css-resolver.js` (parse with `css-tree`, match with `css-select`, fold declarations into `style`).
- One new step in `convertHTML` (`html-parser.js`); runs per fragment, so content, header, and footer are all styled.
- **Cascade:** standard specificity (id > class/attr > type), source order breaks ties, and an element's own inline `style` always wins.
- **`<style>` tags** are extracted and removed so their CSS text never renders as document content.

## Scope

Supported: type/class/id/descendant/grouped selectors, specificity-based cascade, inline-wins, embedded `<style>`.
Not supported (documented): `!important`, at-rules (`@media`/`@supports` — ignored, not applied), external `<link>` stylesheets.

## Dependencies

`css-select`, `css-tree`, `domutils` — same htmlparser2 ecosystem already in the tree, exact-pinned per `.npmrc`, and externalized in the Node builds so they resolve from `node_modules` at runtime.

## Testing

- Unit tests (`tests/css-resolver.test.js`) — selectors, specificity, inline-wins, `<style>` extraction/non-leak, at-rules ignored, functional pseudo-class specificity, malformed-CSS resilience.
- Integration tests (`tests/css-integration.test.js`) — HTML+CSS → `.docx` → asserts color, `text-align`, font, size, background in `document.xml`, including header/footer.
- Verified end-to-end through the built UMD bundle. Full suite green (646 tests).
- Runnable example: `example/example-css-stylesheet.js`. README section added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
