### PR TITLE
Browser-ready builds: zero-config imports + Next.js example

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/docx-diff.yml
+++ b/.github/workflows/docx-diff.yml
@@ -25,13 +25,13 @@ jobs:
           echo "head_ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
 
       - name: Checkout base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: baseline
 
       - name: Setup Node.js for baseline
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: 'npm'
@@ -50,12 +50,12 @@ jobs:
           mv example-node.docx ../baseline.docx
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: current
 
       - name: Setup Node.js for current
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: 'npm'
@@ -92,7 +92,7 @@ jobs:
 
       - name: Post TurboDocx DOCX diff report as PR comment
         if: steps.report.outputs.report != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload TurboDocx DOCX diff report as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: turbodocx-docx-diff-report
           path: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,9 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
 
@@ -29,9 +29,9 @@ jobs:
     needs: build  # Wait for tests to pass before publishing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/  # Configure npm registry for publishing

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
 

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![Type Script](https://shields.io/badge/TypeScript-3178C6?logo=TypeScript&logoColor=FFF&style=flat-square)](https://typescript.org)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord)](https://discord.gg/NYKwz4BcpX)
 [![npm](https://img.shields.io/npm/dm/@turbodocx/html-to-docx)](https://www.npmjs.com/package/@turbodocx/html-to-docx)
-[![Agent Skill](https://img.shields.io/badge/agent_skill-agentskills.io-7C3AED)](https://agentskills.io)
-[![skills.sh](https://skills.sh/b/TurboDocx/quickstart)](https://skills.sh/TurboDocx/quickstart)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-agentskills.io-8A2BE2)](https://agentskills.io)
+[![Quickstart Skill](https://skills.sh/b/TurboDocx/quickstart)](https://github.com/TurboDocx/quickstart)
 [![X](https://img.shields.io/badge/X-@TurboDocx-1DA1F2?logo=x&logoColor=white)](https://twitter.com/TurboDocx)
 [![Embed TurboDocx in Your App in Minutes](https://img.shields.io/badge/Embed%20TurboDocx%20in%20Your%20App%20in%20Minutes-8A2BE2)](https://www.turbodocx.com/use-cases/embedded-api?utm_source=github&utm_medium=repo&utm_campaign=open_source)
 
@@ -44,27 +44,22 @@ Based on the original work and assisted by the original contributors of [private
 
 🛠️ **Developer Experience** - Full TypeScript support, comprehensive documentation, and extensive examples to get you up and running in minutes.
 
-## Install via AI Agent Skill
+## ⚡ Skip the boilerplate — let an agent scaffold it for you
 
-Skip the boilerplate. If you use Claude Code, GitHub Copilot, Cursor, OpenCode, OpenAI Codex CLI, or Gemini CLI, you can install the `turbodocx-html-to-docx` [Agent Skill](https://agentskills.io) and have your AI agent install the package, detect your framework, and generate working integration code in one step:
+Have an AI coding agent (Claude Code, Cursor, Copilot, Codex, Gemini CLI, OpenCode) install `@turbodocx/html-to-docx`, generate a helper module, and write a working framework-appropriate route handler in one step:
 
 ```bash
 npx skills add TurboDocx/quickstart
 ```
 
-Then in your editor, invoke the skill:
+Then run `/turbodocx-html-to-docx` inside your agent. The skill will:
 
-```
-/turbodocx-html-to-docx
-```
-
-The skill will:
 1. Install `@turbodocx/html-to-docx` and any required peer dependencies
 2. Detect your project structure (Express, Next.js, Fastify, NestJS, plain Node.js, etc.)
 3. Generate a helper module and a framework-appropriate route/handler that returns a `.docx` response
-4. Add example usage that matches your existing code patterns
+4. Add example usage matching your existing code patterns
 
-Source for the skill lives at [TurboDocx/quickstart](https://github.com/TurboDocx/quickstart).
+Source: [github.com/TurboDocx/quickstart](https://github.com/TurboDocx/quickstart).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -200,13 +200,25 @@ The library provides a standalone browser build that bundles all dependencies in
 
 ### Build Outputs
 
-When you run `npm run build`, three distribution files are generated:
+When you run `npm run build`, four distribution files are generated:
 
 | File | Format | Size | Dependencies | Use Case |
 |------|--------|------|--------------|----------|
-| `dist/html-to-docx.esm.js` | ES Module | ~1.6 MB | External | Modern bundlers (Webpack, Vite, Rollup) |
-| `dist/html-to-docx.umd.js` | UMD | ~1.6 MB | External | Node.js, AMD, or manual dependency management |
-| `dist/html-to-docx.browser.js` | IIFE | ~2.4 MB | **All bundled** | Direct browser usage, CDN, quick prototypes |
+| `dist/html-to-docx.esm.js` | ES Module | ~1.6 MB | External | Node.js ESM, server-side bundling |
+| `dist/html-to-docx.umd.js` | UMD | ~1.6 MB | External | Node.js `require`, AMD |
+| `dist/html-to-docx.browser.esm.js` | ES Module | ~1.6 MB | **All bundled** | Browser bundlers (Next.js, Vite, webpack) |
+| `dist/html-to-docx.browser.js` | IIFE | ~1.6 MB | **All bundled** | Direct browser usage via `<script>`, CDN |
+
+The package `exports` map points each environment at the right file
+automatically, so consumers don't choose manually:
+
+- **Browser bundlers** (Next.js/Turbopack, Vite, webpack) resolve the `browser`
+  condition to `html-to-docx.browser.esm.js` — a self-contained ESM build with
+  Node polyfills bundled in. `import HTMLtoDOCX from "@turbodocx/html-to-docx"`
+  works with **no extra configuration**. See
+  [`example/nextjs-example`](example/nextjs-example) for a complete app.
+- **Node.js** resolves `import` → `esm.js` and `require` → `umd.js`.
+- **`<script>` tags / CDNs** use `html-to-docx.browser.js` (IIFE) directly by URL.
 
 ### Build Commands
 
@@ -342,7 +354,8 @@ You can also host the browser build on a CDN for easy inclusion:
 await HTMLtoDOCX(htmlString, headerHTMLString, documentOptions, footerHTMLString)
 ```
 
-full fledged examples can be found under `example/`
+Full examples can be found under `example/`, including a complete
+[Next.js app](example/nextjs-example) that generates a `.docx` in the browser.
 
 ### Parameters
 

--- a/example/nextjs-example/.gitignore
+++ b/example/nextjs-example/.gitignore
@@ -1,0 +1,11 @@
+# dependencies
+/node_modules
+
+# next.js
+/.next/
+/out/
+next-env.d.ts
+
+# misc
+*.tsbuildinfo
+.DS_Store

--- a/example/nextjs-example/README.md
+++ b/example/nextjs-example/README.md
@@ -1,0 +1,128 @@
+# Next.js example — `@turbodocx/html-to-docx`
+
+A minimal [Next.js](https://nextjs.org) (App Router, TypeScript) app that turns HTML
+into a downloadable Word `.docx` **entirely in the browser** — no API route, no
+server round-trip. The whole integration is one client component and an `import`.
+
+> Looking for Node.js / server usage? See the other files in [`../`](../) and the
+> root [README](../../README.md). A server-side (Route Handler) variant is shown
+> at the bottom of this file.
+
+## Run it
+
+This example is wired to the **local** copy of the library via
+`"@turbodocx/html-to-docx": "file:../.."`, so it always reflects the source in
+this repo. The published artifacts (`dist/`) are git-ignored and built on demand,
+so build the library once at the repo root first:
+
+```bash
+# from the repository root
+npm install
+npm run build      # produces dist/ that file:../.. links against
+```
+
+Then run the example:
+
+```bash
+cd example/nextjs-example
+npm install
+npm run dev        # http://localhost:3000
+```
+
+In **your own** app you skip all of that — just install from npm:
+
+```bash
+npm install @turbodocx/html-to-docx
+```
+
+## How it works
+
+`app/DocxGenerator.tsx` is a Client Component (`"use client"`). On click it
+generates the document and triggers a download:
+
+```tsx
+"use client";
+
+async function handleGenerate(html: string) {
+  // Imported on click so the library is code-split into its own chunk and is
+  // never evaluated during server rendering.
+  const { default: HTMLtoDOCX } = await import("@turbodocx/html-to-docx");
+
+  // In the browser the library returns a Blob.
+  const blob = await HTMLtoDOCX(html, undefined, { title: "My Document" });
+
+  const url = URL.createObjectURL(blob as Blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "document.docx";
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+```
+
+That's the whole integration — a plain `import`, no bundler config. Two things
+make it work cleanly in Next.js:
+
+1. **Client-side only.** The library returns a `Blob` in the browser and a
+   `Buffer` in Node. Generating in a Client Component on a user action keeps you
+   on the `Blob` path and away from server rendering.
+2. **The package ships a browser build.** Its `exports` map has a `browser`
+   condition that resolves bundlers (Next.js/Turbopack, Vite, webpack) to a
+   self-contained ESM build with Node polyfills already bundled in. So a default
+   `import` just works — no aliases, no `Buffer`/`process` polyfills,
+   no `next.config` changes.
+
+### Simpler still: a top-level import
+
+If you don't need code-splitting, a plain top-level import in a Client Component
+works too — the library has no top-level browser-only side effects, so it is safe
+to import even while the component is prerendered on the server:
+
+```tsx
+"use client";
+import HTMLtoDOCX from "@turbodocx/html-to-docx";
+// ...call HTMLtoDOCX(html, ...) in your click handler
+```
+
+The on-demand `import()` above is preferred only because it keeps the library out
+of your first-load JS. Use whichever fits your app.
+
+### Remote images
+
+The basic HTML → DOCX path needs nothing extra. Remote images (referenced by URL)
+are fetched at generation time, so the image host must allow cross-origin
+requests (CORS) — or pre-convert images to base64 data URLs, or generate
+server-side (below). SVG-to-PNG rasterization (`sharp`) is Node-only; in the
+browser, SVGs are embedded natively (Word 2019+).
+
+## Other bundlers (Vite, webpack, SvelteKit, Astro…)
+
+The same `browser` export condition means these work with a plain `import` too —
+no special configuration. (Older versions of this package, before the browser
+ESM build was added, needed a manual alias + `vite-plugin-node-polyfills` under
+Vite; see [#203](https://github.com/TurboDocx/html-to-docx/issues/203). That
+workaround is no longer required.)
+
+## Server-side variant (optional)
+
+To generate on the server instead (smaller client bundle, `sharp`/SVG
+rasterization available, returns a `Buffer`), use a Route Handler:
+
+```ts
+// app/api/docx/route.ts
+import HTMLtoDOCX from "@turbodocx/html-to-docx";
+
+export async function POST(req: Request) {
+  const { html } = await req.json();
+  const buffer = (await HTMLtoDOCX(html, undefined, {})) as Buffer;
+  return new Response(new Uint8Array(buffer), {
+    headers: {
+      "Content-Type":
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "Content-Disposition": 'attachment; filename="document.docx"',
+    },
+  });
+}
+```
+
+The client then `fetch`es `/api/docx` and downloads the response blob.

--- a/example/nextjs-example/app/DocxGenerator.tsx
+++ b/example/nextjs-example/app/DocxGenerator.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+
+import { EXAMPLES } from "./examples";
+
+const DOCX_MIME =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+export default function DocxGenerator() {
+  const [activeId, setActiveId] = useState(EXAMPLES[0].id);
+  const [html, setHtml] = useState(EXAMPLES[0].html);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const active = EXAMPLES.find((e) => e.id === activeId) ?? EXAMPLES[0];
+
+  // Switching tabs loads that example's markup into the editable textarea.
+  function selectExample(id: string) {
+    const example = EXAMPLES.find((e) => e.id === id);
+    if (!example) return;
+    setActiveId(example.id);
+    setHtml(example.html);
+    setError(null);
+  }
+
+  async function handleGenerate() {
+    setBusy(true);
+    setError(null);
+    try {
+      // Import on demand so the library (and its polyfills) are code-split
+      // into a separate chunk and never evaluated during server rendering.
+      const { default: HTMLtoDOCX } = await import("@turbodocx/html-to-docx");
+
+      // In the browser the library resolves to a Blob; coerce defensively
+      // so this also works if a build ever returns an ArrayBuffer/Buffer.
+      const result = await HTMLtoDOCX(html, undefined, { title: active.title });
+      const blob =
+        result instanceof Blob
+          ? result
+          : new Blob([result as BlobPart], { type: DOCX_MIME });
+
+      downloadBlob(blob, active.filename);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="card">
+      <div className="tabs" role="tablist" aria-label="Example">
+        {EXAMPLES.map((example) => (
+          <button
+            key={example.id}
+            role="tab"
+            type="button"
+            aria-selected={example.id === activeId}
+            className={`tab${example.id === activeId ? " active" : ""}`}
+            onClick={() => selectExample(example.id)}
+          >
+            {example.label}
+          </button>
+        ))}
+      </div>
+
+      <label htmlFor="html-input">HTML source</label>
+      <textarea
+        id="html-input"
+        value={html}
+        onChange={(e) => setHtml(e.target.value)}
+        rows={16}
+        spellCheck={false}
+      />
+      <button onClick={handleGenerate} disabled={busy}>
+        {busy ? "Generating…" : `Generate & download ${active.filename}`}
+      </button>
+      {error && <p className="error">Error: {error}</p>}
+    </section>
+  );
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  // Revoke on the next tick so the browser has started the download first.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/example/nextjs-example/app/examples.ts
+++ b/example/nextjs-example/app/examples.ts
@@ -1,0 +1,147 @@
+// Example HTML documents rendered by <DocxGenerator />.
+// Kept out of the component so the (large, inline-image) markup stays readable.
+
+export interface DocxExample {
+  id: string;
+  label: string;
+  title: string; // document `title` metadata passed to HTMLtoDOCX
+  filename: string; // download filename
+  html: string;
+}
+
+// A small gradient PNG embedded as a base64 data URL. Inlining the image keeps
+// the example self-contained — no network request, no CORS. (Remote <img src>
+// URLs work too, but the host must allow cross-origin requests; see the README.)
+const LOGO_DATA_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPAAAABgCAIAAACsUWiGAAAfzElEQVR42u3Xh3JbR9au4f+yTtUZWxJJ5LCRA3OOIMEE5qBke851/TMe26NEUhRJMYtUlu3xzA2cXns1en0ANsQEyLSHVc8VdL311er/afw/P9248afxPzdPcOMm6Bs3rn3QYdeJBSKG+yQqTmMgzjwkAZLkNUspXi0NMuJN1ieaQYvhf9NK3rI20M4CpEO86wRdSlDrBj3kPQm97wV9oJ+FlQ8DYBAMKZY2TD6yEZCLiFHxacyIfsqDcTBBfp6IkUkwBaaVOPulAGaMxC+zYI78yuZZkiyARfGvJSWlLYMVsJpWfmN3wT0j89t98e8H4CHLkm/At+Q/7DulWfsr+H/N/7kJ+ibom6Bvgr4JuiLokrjTym9sFUjcGWq66N/3gS47Sx4CO+v/MMq6WfuuuSRux6BfWSBiuF9FxUkMxJmHJECScNanKcWrpUFGvM76RDNoMfyvWwln/aYNtLMA6RBvO0GXEtS6QQ+xsw696wV9oJ+FlfcDYLCMpQ0RjFsbiYicgLijH8dAHoyTT+MxMgEmwZQSZ6ZsUjASP8+AWYJx/zKXJPNgQdhZp7QlsAxW0r/aTZNVcNfI/OuewLX+7QHLkofgGwJr3ax9B/7a/O/rG7Rz3H5qWu00awW67ABpF7jWdtZBrStYFre91iFq2nCIO6zwTmvlcd8E/WWCLvoO/DVbJWgkcbup6SI8P4ple0gc2FnD+eHVUl7HuF9nfOKPGnTREPnAhsGIJXJg1Ih8GAN5ME44648TYBJMKTH2aRoUjPinGTBLfmZzLEHmwYL4ZVFJaktgGayklF/ZKrhrpH+9J/51HzxgGfIQfEN+Y98qWe078Nfsbw5Bh1zHYWCBiHgVBTHmJnGQICcs6ebBJimQFrjWp1nQbPhOW4i+QFpBG/OTdvGmA3QqAa0LdJO3RJ8fWi/oY6G3cn7YBsCgEtaGCGf9fhiMWCInboKuX9BNx2FgGTdB3wRdPeiSuFO/yPkBJO40NV30r3tAl50hD4Cd9W+MstZHiJTNcX+BoLWk4tFSIC1OMl6RBc2G76SFcNanraCN+Um7eN0BOpWA1gW6iZ118E0P6AV9LKS87QcDYFAJa0OEs343DEYskRPvR43I+zGQB+Pkw3iUTFQxqcSYKZtMG/GPBTBDMO5PswkyB+aFnXVSWwRLYDn1s900WQGrRvqXuwLX+tf7LEMegIcE1jqrfQu+y/7LMeijMLAM11FEHEdBjLlJHCTIf1HQJKzZWeNaF+O2BMQNax2hpo2KuD/ko2Qc3AT9Xxo0CWidgbK47fMjSE0bDnGHFD48tPK4b4K+cNC/3AP3WYY8AA8JZ/3rN0pW+xZ8l/3VMejDMLAM12FEHEVBjLlJHCQIZ32cVDxaCqTFq4zXWdbwvWomJ6wFtDI/aRMY92mHEtA6QRexsw6+7gY9oJeFFN5prR8MKGFtkOD5oQ1bYkTA+RF5NwrGQJ68z0fJOJgAk0qMfZgC00b8QwHMEM764yxLkDkwLz4tKEltESyB5dQnu2myAlaN9M93xYWDRt+AbzN1CBrZWcNae7SkxzHuV2mvuAm6XkHHPhTADPnIZpmd9RyYF58W4nbTtsUq7KyLaw1WDIw79ctdcI9h3LYH5Ff2MH3BoJHE7aKmi/D8KJbtJv/tQRcNkrdsCAyHxQjIGdbbUTAG8oSzfjcOJsCkEmXvpxzF3k+DAsG4ebM/zII5YWddHOwFsAiWkh9lrcGKkfq0Kn6+C+6xNLkPHhDO+peHaR5s8g34NvOLQ9DBpoMQCBuuA0vgWh9GmZvEQJzA+eHRkiAljtNekQFZ0ExesRbQynykTZy0gw7Fr3WCLnJKAqfdoAf0sqDyug/0gwElpA0SzvrNEBgOixFREjSqiBvXukrcUWavddFN0BVBNx1Y4jACoszOOgbi5IglXHxSkyRICbynjzMga1zvoElIs7PGtS7GHRYQN6z1TdA1DrrxIATCxh8y6FftoEPxa52gi9hZB0p0gx4WVDhrrQ/0KyFtgOBaa0NhMSxgra03OTAKxsjbsQjJg3EwoUSZuT3IlBF7Nw0KhLN+P8PiZBbMiQ/zSkJbAItgKfnBbposgxUj9XFVfLoL7rF0ufsE4s5oD8E3mZ8dg94PgbDRtG+JgwiIMheJgTjhrA8TiltLgpQ4SntEBmQN71Ez4ayPW0Ar85WpiNuvdfjL4rbX+iboywZdEndS+ciWgMSdoqaLcK2LZafJnypo57i91HTpPV0at4/cBH3+oG14frwvxMkMKI87oc2DBbCYfG83TZbAspH6sCJwrT/eZWlyD9wnnPWnB+Ah+Cb96QsEDdxaAiTFYcoj0iBjeA+zhLPmtdZamI+0iuM20K74tQ7QSeysA6+6QDfoYUHlpBf0gX4lpA0Qzvp0EAyFxbB4PWJYr3NgFIyRN2MRkq9iXIkyUzaZNGJvp8A0wbV+V4iTGTArcK3fz4MFsKiaNucHWDaSH1bEx1Vwl9lZ3wP3ySf2IHWxoPdCIGw07VkC496PMBeJghiBuG+Crh60sKhpoyJuXGstD8Ytu2lir3XRpBF9OwWmyTtWYHbWM2BWvJ+LXd+gH1YLGkncTdR00U3QDkGXx81HSPB0AJTEDYaN8OkIyIFRgmut5cG4EmFvJsCkEX0zBaYJZ/22wGJkBsyKd3NKXJsHC2Ax8c5umiyBZSP5fkVg3B9WWYrcBfcIxK2PkI8PwMP0R4egA427QRAymnbDAtd6L8JcJApihLPejytuLQGS4iDlEWmQMbwHWcJZHzaDFuYjreKoDbSDDtBJjon/uKuKbhY4lrhtvaBPCWr9hLM+GQCDITEk/vBBl8SdeCf3NJC4k9R00Z84aJAGGcNzkCWHrBm0MDvrVnHUVqZq3MdEr7X23xa0Zh/WBQBx24dH8aSei1dZ64sFjWv9fpWlyF1wj3DWH+4rae0BeJj+cJGgG3fDYs8CEWZnHQUxss/iTXbTtgRIigsHjXTZuNbkqBV8Nmib/6gTdIFuFlCOe0Av6FOCWj/hrF8NgMGQGBInw0b4ZATkwCg5HbXIGMiDcSXCXqMJI/p6EkwRjPvNdIwUwIywdzquzYF5sJB4azdNFsGSkXy3LOoddMPLIAgZjS/DYtcCEdZEoiBGOOu9uOLSEiAp9lNuZ2nDs58h+gLJgmbmJS0C1/qwTfFp7aCD/AGCtp3mLDIKyuOOsD9t0Og+eJD6nYJGEDeeH/8VQQM4P8LUtFERdz2C1qZZjBTAjHgzq8S1OTAPFshbtgiWjMTbZfEOrbAkWQV3yXt2L8l9k/vgQep97YNGdtZwfuir+upBa1nQzLykRRy0gjbFp7WDDmJn7T/sBF2gmwWUox7QWyao9RGMWxsIiUEBax1+NQxGQI6c5CwyCsZAXokwc3uQCTAJpshrNs3srAtgRryZjdpN2+aqsLMurjWQuBPUdFHdg94JgpDRiDDulxZrIhEQJbDWLi0OEmIv6RYpkDY8exnyOwStBRTeaa087qsHHXo1DEZAjuA9rY2BfNhumtj3dNGEcb6gEcT9RjVtLpDZmHPc1y5oJHH/uYJGdtb2+eGnpg2HuM8MuqiPHLN+MBAUg2DICB0PgxGQI7zTr0bBGMgrFjsZdxQ5mQCTBOM+nYqSaVAQ9k4XL5BZMAfm469Lzw9t0Ui8WRJ4frxdYUmyCu4SzvrdPSWl3QcPUu8cgvbXOGgtpri0OEiI3aRbpEDa8OxmCGe9lwXNzFsG495vBW2gnRwQvdZaJ+hi/gM5P2w9oFcJaH2Esz7qBwNBMSiuFHR53BYzU32S/+MHbYO1Tmn3UiVxOwa9HQBBo3E7JHbCwGJNJAKipKZBu3czZK9SlmHcZL8FtHr+GEGjirjxnq6y1tciaG0BLBoJhHG/WWZJsgJWCax1SrsH7qfeftmgi+IgIXaTLmcpQ2etL5DfKeiDbtADepWA1kc468N+FBQDAuIOHQ2BYTBCjkfCJAdGwZhiMXN7kHEj8moCTBLO+mSKRck0KIjTGSWmzVYxF1deM+e4rx500T1wP+kc9FYABEFIbIeBxRpJBETJDospTQ7iAtf6ZRKkDPfLNMG11rLMQ5rFXgtoVbxaG2gndta+/Q7QCbqYf/8zQZOAZmeNa12M+w8YNLB3OqbNxJzjniPFtQYLBq51/M0SWGZ21itglbxldxMXCvrOVgAEjYsHbdthlLXe7D9k0Jpf0TvtvNbXKOjjPBg3IiUmCMatTYFpcVKIyGDPgFkwFzuZ01mfzoMFI366KF4vgWWWICtglXDWb+4qSQf3km9qE7TWSCxwDYLebQGtildrA+3EztpXogN0Mr/CO611gx4loPUSPD+0/qAYEIeDRuhwCAyDEXI0EiY5MOrMjrsob2Dc1vEEecUm2bUJGtlZw1rrI+RcQb8IgKDRgDDurTBrJBaIEDg/mrQYiIudhEskQcpw76QJZ/0yA7LMQ5pFSdDEq7V6y+K21/o6BB08HALD5XCttRwYDV3foEWcmjYg7tMlliDLYIXAWie1u+Be8rVz0Eji/uMEDSrWut5BF/WSA9YH+gNiwFHwYBAMgWGCa63lwKgSZkdjIG9YR+NggnDWx5MsQqbAtHhVUKLaTBWzMeWEzYF5I36yIOoctO93C3o74RJJkDLcbIelQYZ5SFbgWr9sUbxaK2gjeH5oHaCT+ZS9LtANehS/1ks46/0+FBD94loHDeydjmqFqHPc1y3oTT8IGA2bQfEiBMKskVggQjjrrajSpMVAXJQE7Rz3mUHbsuJlM2hx203bWkEb2SVXC5r4NTtrXOti3NcsaBueH/xN1Fk7r3VUK4AZMBs7tpsmc2DeiL9aECeLYIklyDJYIaeVVsHdxOnvHzQoXWuQNPRU6wskDTLsSwRdogt0K36th+Baa30B0S/2B4zg/iAYAsPkYDhERkAOjCphdojGDOswD8YJrvXRRIRMgilRo6BjrxbEyWIljNu2TE7ZSvzLBG2zQKSMTvxFFMQErvVWAiQN11aK6AskDTLMTbJipxm0KB6tFbQRO2tviXbQwXzKtQu6PO4wq1vQRQUwA2ZV0+rwsM05Kon7ZAF8NmhtJc6DTVbB3cSJY9DP/SAAgmIzBMKsoZxFIO7rFDSys7bX+voFXRH3wVCIDIMqQZupJmMgD8bJIZtgFpkEU+JoWolohSpmokey1mDOiB3PC1zrV4ssTpbAMrlc0Lef+0HAKA0a6bIbyHULGlHWHq0iaJt3pw20gw7mU152gi7Qrfi1HsJZ7/aCvoDoFxB3cG8ADIIhgmutjYCcEmL2+VE0Zlw8aHCkmjaDPR1xjvv3Cnr1PEGLqmv9PMQaSBhYhLPejCiNWhTExIt4k0iApOF6kSKc9Va6kptkBMa93ax4tBbQSuoYNCqJW+z1G4G9ATAIhkgdg9bsO2QCXCpobRbMGbGjeXG8ABZZnCyVg7gT2gpYTbxyDHoD+Y07GwHxuwVt22IpcB2CLo+bjxDfbg+oEvRuvxHYHQCDYIjwTu8NgxGQU0Jsf9RReH8M5AnGfTBukQkwKezDI6JNgwKYiR5eKGiky46TRXD5oL3XI2jnuF2mabPWWpq5SUZsZUGz4tFaQCvhrLfbQDvoYN7tDhO3rRN0KT6tm3DWL3tAr1/0iZoFTULMTPV+7noELWLUdNGlgi5aAatx56DXfcBv3FkPiI0gCLEGEgYW4ayfR5RGLepsM9Yk4iBhuDaT5ApBF7WAVrJNSoN2iNu73X49gkblcV84aG2cWWQCTIqDKSWiTVdRiCqHbAbMgjlxNA8WWIwsgiVyzJaVuLYCVuPHXy5o0qhFGh3jPkfQTZtJoi+QFEgzO+uM2MqCZpdz0LZtUtzpqmtNQfNOa52gS/Fp3YSz3ukBvX7RJ172G4ESA2CQ7A4GyRAYBiNKiJnbg4wa4b0xkCcXCBpNgWlQUE2btQazRu2CRiv1DtoG58cZQT+PgThIGE3Pk4Sz3kyBNHORjHiRLePWmkELsbPW54fWBtqZd6uGQQNY698vaIe1tk2Ig8lwzYM+nAcLLFZukUDccW0ZrMSPHINe8wG/cWctINaDVYRAmGww6w4PNomAqKhZ0ADX+ncLGvX4xaWCfjkYJENgGIyI3RwYNUIlxsgeyzO78nEwIfYnwzLYU2AaFCL7dtNkBswa0YM54RR3jNQ56NtrAbGOguyLB4102S5yqaBtnhetoA20M6+y1QE6y/i0LoJxaz1+0Svg/Ajs9IMBMEh01kNgGIwEJGgkcf9+QYsoNV1U76BvrfkclcR9/qA1S2nQIiAqNmKNIg4SRhN7zpIgxVwkLfD82Mwqbq0ZtJALBI3K4z4zaNArdvoM/04/GACDxCHo8rj1Wtcj6L1JxdKmqpiOKPusAGaM6P6swLU+mGcxsgAWCWd9uKTEtWWwEj90DPoZ8hm3n/kFrvVakN0hIRAmlwzaOe4vG7RD3F7ls0EXdZFt1g2qBL3dZ/i3+8FAOVxrbQgMK0GG58fLnBF6OQrGCGe9m2dhMg4mhJ21pU1aznHXO2i0BJZjTkF7vmzQYCPaKGoU9PMMyCpurRm0kM1KraCNeTZlrW0doFPxal2Es97qBj0+0StKgkYVcX+hoBHEXaOgI/uz4mAOzLNouQWwGOW+yRJYjh1cOuhnARBkd0gIhAlnvWYpDQ4iYj3aKGIgbjStJ4i+PZIgxVwkLSqCdtJMNsmXDRrAWn/ZoCvifjkWJnkwLuydtrRJMAWmyR4rgBkjsjcrMO79ORYl82CBXDLop17gM24/9YtzBW2DtW7Q6hi0LS2eo0yTc9x1C9pBt0/0CFhr/1Yf6AcDZHsgQAbBEBhWgmxnxFFoJwdGSWnQtjwYF7sTIblAJsEUwKCRxB2hpouud9DowkGDGIgbjesJkAQp1lQG497IKC4tC5qJnbU+P7RW0MY8ymY76Cjj1TqJQ9z1DpoEmZnqnbK4c2CUvGRj7FJBl8RdvtZawYjszghc6705FiXzYIFw1vuLSkxbKuUY9BMv8Bm3n/jF00ClOyQIQgTPD80CEbEWbRAxEDca1xJkvZIuu4nUO2hUHnfdg94aCJQbBEPCXuuiESO4nQOjhLPeGWMhkgfjws66eIFMgEkwZb2sedA2WOuYthgriftiQQNc65KsgyBEnrHw7csHLRqpaXOB1DRom3ujBbRW8iictdYOOhSv1kk4680u0O0TPeJFL+irop+Uxm0bBEP+2gSNIO66B61FyRyoWdDOcd966gcBdtWgn0UbnMWMxmdxwlnzWmtJ1kRSYj0NMopLy4JmooNGDnFfPWjQI16I6nHXI2gbnh98VVcL2t7psDYBJsGUtWM3TaZBwYggjHt3lkXJHJgneH5oi2ApuucU9NePkde49dgnnvhBgN0mQRAinPXTsHJHs0BEPIs0iHoHjeys7bW+etBFnWSTdaEz4/Zt9oI+0E9e9PvJABgEQ0qAbQ07Cm6NgBzBtd4eDZExkBcXDhpJ3GcGbZsD82SPLUQuErS7/kEjiLseQa+ly7i0DMgSXGutBbQyt7LRBtpBh+LROsnzSl1e0S1qFjQJMLyn6x50RdzF8wNMG7jW1ssZMMsiZA7ME856d0GJOliM7n6BoMEdLQws8TTSIKIgZjQ+jRPO+lkCJFlTmapxZ0CWrJOrBU08mp01rnUdgy6PWwdtppoMG8EXIyBHOOutURYiYyAvMO7tcTABJsPbstZg2rB2CuJcQdtgrfURcq6gH3mA17j1yCce+0GA3SbBchB3PYN2iJuspUC6sTZBo/K4S4LGtda6vKJbPO8xfM97QV+5zT4/6QcDYFAJsMsGXWFMbOeD9Q1ai5BZ8EWD1m6TAKh90A1P41UkWCNJimcpkFaatAzIEjtr11ozaKnkVjhrrQ20Kx6tg1wyaFQR9zmC1ux7umjYCLwYATmyVaIi7ksFrU2BacNCGPfODIuQWTBH4PyIagtgMfry0kGX8LPbJACCRE91SLmjhYElnkRA1FHDkxhxiLtWQSOHuOsWtDgjaK0fDIBBxc82h8CwESgxQjBu3uwXo2BMbOWDcoGMgwkwGd7Cph3irk/QC1WC/qcHeI1b6FJBF4WBJUqCdo67PkHb7PPjXEGvtYI20K54tA7CWa93Iq/oEhj3Rg/oBX3kAkEjibs+QZfEHVa2WU2DdjAPFiI7ZwctzgzaFgBB8piFbp0ZNK714wiIGg2PY4SzfhIHCdZIkuJpCqSVJgcZYmftepYFzaCFuZ9dImiEcXeJjW7j4kGXx+1n5w9ay7EgGQVjws46pOXBOJgIv7CbJpNgyrC2psV2AcxUMUt22Jx1saBLeIBX/NMH/OwWCYAg4awfhZTbDsKiLkEjyrpJq0fQ5XHzEeJe7wBVgl7vNrzrPaAX9JGNPl+5fjCg+JmZajJkBJ4PgxFyRtDgfEGT4vkBpozw1rTYRgVWEfflg3Z99ZMbeIyrBU30EVL3oMH5g7a5nmZBM2gRz1qraFPcWjvhrNc6QKdHdImqQVfEvdHrI/UIWguSHCgPuigPxsFESEyCKSOMMO6tArPIDJglnPX2nBLR5sFCZLu+Qdvg/Dgj6EfWHREBUaPhUYxw1o/jlRpJQuBaP0kpTVoaZIhuOguaK1HcxbW21SNodIWgNwbBkBEoMUwwbi0HRsXmWEAukDwYBxOhTWzaIe7aBY3mqwT9oxt4jK9/9IqffMDPbpULEFjr21oIhMW5grY9ZjFw3qCL0iBDnpLSoB3ivljQWgfo9DiCuL1r3aAH9JL1Xh/pA/1gQPGzkqCd4/ZvDJPnbIRdKuiSuEObpedHrYIGEW0OzEe2ahO0dovUI2hxZtC2BEiClNKopUGG2Fk3lciCZuZ6Unp+PG0FbYpbaycOQXd4RD2CBvZaFw0aVwr6+ZgSdJAH46HndtNkAkwa4c0p8WIaFJhVboZA3DUPGn02aC2o3NZCICz+ad1xFgFRogc7BuKsgSRE1aCRnbW91rUL2ua01lcNWuurol/xMXutiwYN//oQGCac9cYIC5CcMzvroFaroJEu2yKfC7poDsxbzkH/4AYe42uEcf/oY7eIHwTIBYJGFogYVwuaNGpXCPpJC2gt49baCK611uERneJZF+gGPeXOiPsqQWv2YT0CahW0CFPTBsS9OQ0KYIa8YLOKpc2BeevF2UGLqwddFHJ2/qC1GIizBpIQGPejpNKopUCa2Fk3Pc6ALGhmrsdlQZfHfWbQoFM86zJKg66Iu8ZBV8S9PhwgIyAnNkaVoDYG8mA8tGE3XW4CTIrNKTDNzh00mqsWNKoS9A9e4AN+ECA/sqByy0FI4Fr/ZIGIceenKDkjaFCzoDWXonf682vdRp6ydlAlaOB52gW6QQ951uMlvaAP9Cs+tjbgyL82CIZIDYKuiLu41mDCuHjQNn1hU9b6CDlH0E1f/cMF3MAjfvACH/ts0ERvds2CdljrBnKpoG1NjzJVZEVxrW0toFVxaW2Es37SDjrcjuoSNKpl0E7GQMlagwkjtDEpnk9VCpNpUCCw1pY2C+asTaeg//IPF3Ab5wu6Yq1/ZOcI+sfwbWGBiHGH/cSiIMYaSFzg+fHPpNKopUCaPKqUAVl25aDb3aJWQZfH7dP6wQAYBENkjQ0zPxlxtp7zS9+jYAzkg+sXChrVI+jvXcBtfPW9R/zDW+lr4gN+Amt9SwuCkKgatLh60EWpco9I7YJGbaDdLTrEk07D86QLdIMe8rTHW64X9Al7rYsGjPMFjWoVtAhR00XnD1qbUSxtttTlg0b1CNo57jODtsVBAiSVBgcpYmet11rLgCxrUh41g5YyLq2V1DhoG6611gv6PBcL2rbGdNn2HVIl6LWcEtBGwRjIB9fspsuNG6H1CYFrvTHFwmQaFMjzSjNgNnzBoMH5g9YCyi0tCELih9BtEQYWiBB9gURBjN0hcVERd4NWq6DL47560KW6QDeTtdZ6QZ/iZU/7wYDhKzFIcK2fDfnJMBgRVYMuiTuorLNLBm2bLvecFUIXC/rvLuA2vkK41t972dfEB/zkjKABrvUPYWAZ5wsa1CPoEs2gRXFprYSzftQG2t2iQ2DcjztBF+gmFwgaSdy1CxpdLOjg+gSYrBQiU2Ca6LILIR5sMgNmwxtnBy2uHrSToDh/0Fq00h0SE7jWPyaUBi0JUsTOuvGndBUZ1qRcLWhnjzuMqwVNvOz8QWtDzE+GndlZB7QcGAVjpHh+gHEjuDYhnOKubdDoAkHbfMBfRif+fQAEBZ4f/wgDy7j9jwj5oVKtgkaXCbqolTyqVC3uDsP9qBN0gW7yuNtDeqroVbzMTDXpN3xPBsAgcQgalQddlAOjoFrQIkhNF50/aK2ghB3MhNcdgm78y9+agMv46m9u8XcP8AJfOYi7FkHb8J6uQdCi8ccUSIOM+CkLmkGL0oQwbq3NJdrFuYK2Pe7ykG5wlaBt1dfaNgxGFL+WA6NgLPB0TO90ibwRfDYucK3XJlmITIFpAlmHtSsE/Ze/ucXfPcDLvipXq6DFbdO0WWstyu6QmPghDhJKg4MkwbXW0iDDPhs0adJqFXRF3OcP+nEf6K9igDxhg8ye7SEwLKoGXRJ34Gnp+XHJoJGdNaz1BYL+v39rAi6jJOi/eSp9RbzAR/RU+5WvtQAIiu9Dt5yFjdvfW+SSQZfHXZQkP5KLB10ed0nQWitoc4l28c8Ow12iE3SRR10e0g16QK943OeodkGjKwT9bKJSiEyCKYJrrRXATGjNMej/bQIu4y//6xZOcV856OAtccmgbTHxA4rf/kzQtoYfUiANMqzxh0zJ+fFjFjQrTVoLuUDQ4syg5Z7WekCvW4JGnw1aG2Q+MuTMztqvjYAcGA08sZsmYyBvBFHVuCfBFFlj00HnoAvOQd+48cd3E/SNm6Bv3Liu/j8tVf+sWd1JBAAAAABJRU5ErkJggg==";
+
+// 1. Simple — the original one-paragraph demo.
+export const SIMPLE_HTML = `<h1>Hello from the browser</h1>
+<p>This <strong>.docx</strong> was generated entirely client-side with
+<code>@turbodocx/html-to-docx</code> &mdash; no server round-trip.</p>
+<ul>
+  <li>Pure JavaScript, no headless browser or binaries</li>
+  <li>Returns a <code>Blob</code> in the browser</li>
+  <li>Downloaded with <code>URL.createObjectURL</code></li>
+</ul>`;
+
+// 2. Complex — exercises nested elements, tables, an embedded image, code
+//    blocks, and the full inline-formatting pipeline.
+export const COMPLEX_HTML = `<h1>Complex document showcase</h1>
+<p>
+  This document exercises the <strong>full</strong> <em>inline</em> and
+  <u>block</u> formatting pipeline: <s>strikethrough</s>, <code>inline code</code>,
+  custom colors, font sizes and families, hyperlinks, nested lists, tables, and an
+  embedded image &mdash; all rendered
+  <strong><em><u>client-side</u></em></strong> in the browser.
+</p>
+
+<h2>1. Inline formatting</h2>
+<p>
+  Combine <strong>bold</strong>, <em>italic</em>, <u>underline</u>, and
+  <s>strikethrough</s>, or <strong><em><u>stack them together</u></em></strong>.
+  Inline <code>monospace</code> works too, alongside
+  <a href="https://github.com/TurboDocx/html-to-docx">hyperlinks</a>,
+  super<sup>script</sup>, and sub<sub>script</sub>.
+</p>
+
+<h2>2. Color, size &amp; font</h2>
+<p>
+  Inline styles control <span style="color: #4f46e5;">text color</span>,
+  <span style="font-size: 22px;">font size</span>, and
+  <span style="font-family: 'Courier New', monospace;">font family</span>
+  &mdash; independently or all at once.
+</p>
+<p style="font-family: Georgia, serif; font-size: 18px; color: #1d4ed8;">
+  This entire paragraph is <strong>Georgia, 18px, blue</strong> via a style on the
+  <code>&lt;p&gt;</code> itself.
+</p>
+<p>
+  <span style="font-size: 26px; color: #16a34a;">Big&nbsp;green</span>,
+  <span style="font-size: 10px; color: #6b7280;">small grey</span>, and
+  <span style="background-color: #fef08a; color: #92400e;">highlighted</span>
+  text share a single line.
+</p>
+<p>
+  Everything combined:
+  <span style="font-family: 'Times New Roman', serif; font-size: 16px; color: #b45309;"><strong><em>serif bold italic in amber</em></strong></span>.
+</p>
+
+<h2>3. Nested lists</h2>
+<ol>
+  <li>First top-level item
+    <ul>
+      <li>Nested bullet with <strong>bold</strong> text</li>
+      <li>Nested bullet with <code>code</code>
+        <ul>
+          <li>Even <em>deeper</em> nesting</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li>Second item with <em>emphasis</em></li>
+  <li>Third item</li>
+</ol>
+
+<h2>4. Table</h2>
+<table border="1" style="border-collapse: collapse; width: 100%;">
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Browser</th>
+      <th>Node.js</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Returns</td>
+      <td><code>Blob</code></td>
+      <td><code>Buffer</code></td>
+    </tr>
+    <tr>
+      <td>SVG &rarr; PNG (<code>sharp</code>)</td>
+      <td><s>Not available</s></td>
+      <td><strong>Available</strong></td>
+    </tr>
+    <tr>
+      <td>Setup</td>
+      <td><em>Zero config</em></td>
+      <td><em>Zero config</em></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>5. Embedded image</h2>
+<p>A base64-encoded PNG embedded inline (no network request needed):</p>
+<p><img src="${LOGO_DATA_URL}" alt="Gradient banner" width="240" height="96" /></p>
+
+<h2>6. Code block</h2>
+<pre><code>import HTMLtoDOCX from "@turbodocx/html-to-docx";
+
+const blob = await HTMLtoDOCX(html, undefined, {
+  title: "My Document",
+});</code></pre>
+
+<h2>7. Blockquote</h2>
+<blockquote>
+  <p>&ldquo;The whole integration is one client component and an <code>import</code>.&rdquo;</p>
+</blockquote>
+
+<hr />
+<p style="text-align: center;"><em>Generated with @turbodocx/html-to-docx</em></p>`;
+
+export const EXAMPLES: DocxExample[] = [
+  {
+    id: "simple",
+    label: "Simple",
+    title: "TurboDocx Next.js Example — Simple",
+    filename: "simple.docx",
+    html: SIMPLE_HTML,
+  },
+  {
+    id: "complex",
+    label: "Complex",
+    title: "TurboDocx Next.js Example — Complex",
+    filename: "complex.docx",
+    html: COMPLEX_HTML,
+  },
+];

--- a/example/nextjs-example/app/globals.css
+++ b/example/nextjs-example/app/globals.css
@@ -1,0 +1,97 @@
+:root {
+  color-scheme: light dark;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  padding: 2.5rem 1.25rem;
+  display: flex;
+  justify-content: center;
+}
+
+main {
+  width: 100%;
+  max-width: 640px;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+  border-radius: 12px;
+  margin: 1.5rem 0;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+}
+
+.tab {
+  align-self: auto;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: transparent;
+  color: inherit;
+  opacity: 0.6;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.tab.active {
+  opacity: 1;
+  border-bottom-color: #4f46e5;
+}
+
+textarea {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+  background: transparent;
+  color: inherit;
+  resize: vertical;
+}
+
+button {
+  align-self: flex-start;
+  padding: 0.6rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  background: #4f46e5;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.error {
+  color: #dc2626;
+  font-size: 0.9rem;
+}
+
+.hint {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}

--- a/example/nextjs-example/app/layout.tsx
+++ b/example/nextjs-example/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "@turbodocx/html-to-docx · Next.js example",
+  description: "Generate a Word .docx in the browser with @turbodocx/html-to-docx",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/example/nextjs-example/app/page.tsx
+++ b/example/nextjs-example/app/page.tsx
@@ -1,0 +1,18 @@
+import DocxGenerator from "./DocxGenerator";
+
+export default function Home() {
+  return (
+    <main>
+      <h1>@turbodocx/html-to-docx + Next.js</h1>
+      <p>
+        Type some HTML, click the button, and a Word document is generated{" "}
+        <strong>in your browser</strong> and downloaded. No API route, no server.
+      </p>
+      <DocxGenerator />
+      <p className="hint">
+        See the <code>README.md</code> in this folder for how it works and for a
+        server-side (Route Handler) variant.
+      </p>
+    </main>
+  );
+}

--- a/example/nextjs-example/next.config.ts
+++ b/example/nextjs-example/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/example/nextjs-example/package-lock.json
+++ b/example/nextjs-example/package-lock.json
@@ -1,0 +1,1094 @@
+{
+  "name": "html-to-docx-nextjs-example",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "html-to-docx-nextjs-example",
+      "version": "0.1.0",
+      "dependencies": {
+        "@turbodocx/html-to-docx": "file:../..",
+        "next": "^16.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "../..": {
+      "name": "@turbodocx/html-to-docx",
+      "version": "1.21.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.12.2",
+        "color-name": "^1.1.4",
+        "html-entities": "^2.3.3",
+        "html-minifier-terser": "^7.2.0",
+        "htmlparser2": "^10.0.0",
+        "image-size": "^2.0.2",
+        "jszip": "^3.7.1",
+        "lodash": "^4.17.21",
+        "lru-cache": "^10.4.3",
+        "mime-types": "^2.1.35",
+        "nanoid": "^3.1.25",
+        "xmlbuilder2": "2.1.2"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.28.4",
+        "@babel/preset-env": "^7.28.3",
+        "@commitlint/cli": "^19.8.1",
+        "@commitlint/config-conventional": "^13.1.0",
+        "@rollup/plugin-commonjs": "^28.0.3",
+        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-node-resolve": "^13.1.1",
+        "@rollup/plugin-terser": "1.0.0",
+        "babel-jest": "^30.2.0",
+        "cross-env": "^7.0.3",
+        "diff": "^5.2.0",
+        "eslint": "^7.32.0",
+        "eslint-config-airbnb-base": "^14.2.1",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-import": "^2.24.2",
+        "eslint-plugin-prettier": "^4.0.0",
+        "husky": "^7.0.0",
+        "jest": "^29.7.0",
+        "lint-staged": "^11.1.2",
+        "lodash-es": "^4.17.21",
+        "prettier": "^2.4.1",
+        "rollup": "^2.62.0",
+        "rollup-plugin-cleaner": "^1.0.0",
+        "rollup-plugin-polyfill-node": "^0.13.0",
+        "standard-version": "^9.3.1",
+        "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.7.tgz",
+      "integrity": "sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.7.tgz",
+      "integrity": "sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.7.tgz",
+      "integrity": "sha512-O3IRSv1ZBL1zs0WrIgefTEcTKFVn+ryxBNe54erJ6KsD+2f/Mmt7g2jOYh8PSBdUwPtKQJuCsTMlZ7tIu2AcsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.7.tgz",
+      "integrity": "sha512-Re6PZtjBDd0aMU+VcZcC/PrIvj4WhrjDYtMhhCVQamWN4L90EVP0pcEOBQD25prSlw7OzNw5QpHLWMilRLsRNw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.7.tgz",
+      "integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.7.tgz",
+      "integrity": "sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.7.tgz",
+      "integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.7.tgz",
+      "integrity": "sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.7.tgz",
+      "integrity": "sha512-J4WlM72NMk076Qsg0jTdK3SNXatlSdnjW7L7oNGLst1tAGjHrJh/FYi+pw9wyIjEtGRKDNzD0zuiY16oWYWVaw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@turbodocx/html-to-docx": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.35",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
+      "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.7.tgz",
+      "integrity": "sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.7",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.7",
+        "@next/swc-darwin-x64": "16.2.7",
+        "@next/swc-linux-arm64-gnu": "16.2.7",
+        "@next/swc-linux-arm64-musl": "16.2.7",
+        "@next/swc-linux-x64-gnu": "16.2.7",
+        "@next/swc-linux-x64-musl": "16.2.7",
+        "@next/swc-win32-arm64-msvc": "16.2.7",
+        "@next/swc-win32-x64-msvc": "16.2.7",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/example/nextjs-example/package.json
+++ b/example/nextjs-example/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "html-to-docx-nextjs-example",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Minimal Next.js (App Router) example showing how to generate a .docx in the browser with @turbodocx/html-to-docx",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@turbodocx/html-to-docx": "file:../..",
+    "next": "^16.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/example/nextjs-example/tsconfig.json
+++ b/example/nextjs-example/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -42,9 +42,24 @@
     "rtl",
     "right to left"
   ],
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "node": {
+        "import": "./dist/html-to-docx.esm.js",
+        "require": "./dist/html-to-docx.umd.js"
+      },
+      "browser": "./dist/html-to-docx.browser.esm.js",
+      "import": "./dist/html-to-docx.esm.js",
+      "require": "./dist/html-to-docx.umd.js",
+      "default": "./dist/html-to-docx.esm.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "main": "dist/html-to-docx.umd.js",
   "module": "dist/html-to-docx.esm.js",
-  "browser": "dist/html-to-docx.browser.js",
+  "browser": "dist/html-to-docx.browser.esm.js",
   "types": "index.d.ts",
   "files": [
     "dist",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,38 @@ const browserOnly = process.env.BUILD_TARGET === 'browser';
 
 const banner = `// ${meta.homepage} v${meta.version} Copyright ${new Date().getFullYear()} ${meta.author}`;
 
+// Replace the optional native `sharp` dependency with a null stub in browser
+// builds. The IIFE build stubs sharp via output.globals, but that only works for
+// iife/umd formats; an ESM output needs a real module to import, so we resolve
+// `sharp` to a virtual module that exports null. SVG rasterization (the only
+// sharp consumer) then throws its existing "Sharp is not installed" error if
+// actually invoked, while basic generation works untouched.
+const stubSharpForBrowser = () => ({
+  name: 'stub-sharp-for-browser',
+  resolveId(source) {
+    if (source === 'sharp') return '\0sharp-stub';
+    return null;
+  },
+  load(id) {
+    if (id === '\0sharp-stub') return 'export default null;';
+    return null;
+  },
+  // `sharp` is loaded via `require('sharp')` inside a try/catch in an ES module
+  // (src/utils/image.js). @rollup/plugin-commonjs leaves try/catch requires in
+  // mixed ES modules untransformed (default `ignoreTryCatch`), so `resolveId`
+  // above never sees `sharp` and the bare `require('sharp')` survives into the
+  // bundle. A downstream bundler (Next.js/webpack) then statically resolves it
+  // and pulls in sharp's Node-native deps (detect-libc -> child_process),
+  // breaking the browser build. Neutralize the require in our own source so no
+  // `sharp` specifier remains for any consumer to follow.
+  transform(code, id) {
+    if (id.includes('node_modules') || !/require\(\s*(['"])sharp\1\s*\)/.test(code)) {
+      return null;
+    }
+    return { code: code.replace(/require\(\s*(['"])sharp\1\s*\)/g, 'null'), map: null };
+  },
+});
+
 // Node.js / Library build configuration (ESM and UMD)
 const libraryConfig = {
   input: 'index.js',
@@ -84,6 +116,35 @@ const browserConfig = {
   },
 };
 
-const configs = [libraryConfig, browserConfig];
+// Browser ESM build: same self-contained, polyfilled bundle as the IIFE, but
+// emitted as an ES module with a real default export. This is what bundlers
+// (Next.js, Vite, webpack) resolve via the package `exports` "browser"
+// condition, so `import HTMLtoDOCX from '@turbodocx/html-to-docx'` works with no
+// extra configuration. `sharp` is replaced by a null stub (see above).
+const browserEsmConfig = {
+  input: 'index.js',
+  plugins: [
+    stubSharpForBrowser(),
+    resolve({
+      browser: true,
+      preferBuiltins: false,
+    }),
+    json(),
+    commonjs(),
+    nodePolyfills(),
+    terser({
+      mangle: isProduction,
+      compress: isProduction,
+    }),
+  ],
+  output: {
+    file: 'dist/html-to-docx.browser.esm.js',
+    format: 'es',
+    sourcemap: !isProduction,
+    banner,
+  },
+};
 
-export default browserOnly ? [browserConfig] : configs;
+const configs = [libraryConfig, browserConfig, browserEsmConfig];
+
+export default browserOnly ? [browserConfig, browserEsmConfig] : configs;


### PR DESCRIPTION
 - **feat:** zero-config browser imports — browser ESM build + package exports, plus a Next.js example (#205)
  - **ci:** bump JS GitHub Actions to their Node-24-bundled versions
  - **docs:** refresh agent-skill callout to match TurboDocx SDK READMEs