### PR TITLE
chore(deps): move from image-size to probe-image-size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
         "html-entities": "^2.3.3",
         "html-minifier-terser": "^7.2.0",
         "htmlparser2": "^10.0.0",
-        "image-size": "^2.0.2",
         "jszip": "^3.7.1",
         "lodash": "^4.17.21",
         "lru-cache": "^10.4.3",
         "mime-types": "^2.1.35",
         "nanoid": "^3.1.25",
+        "probe-image-size": "^7.2.3",
         "xmlbuilder2": "2.1.2"
       },
       "devDependencies": {
@@ -7807,6 +7807,18 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -7814,18 +7826,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "node_modules/immediate": {
@@ -11048,8 +11048,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
@@ -11358,8 +11357,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -11383,6 +11381,32 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -11979,6 +12003,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/probe-image-size": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.3.0.tgz",
+      "integrity": "sha512-7CaDeBwiAbh6ohXsvLbAZhO7wzsZAmaevfxe39qvCwRh8LyaZfDlBGGLU1CCTgrTLtCOdwBBhjOrIHaIIimHfQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
       }
     },
     "node_modules/process-nextick-args": {
@@ -12582,6 +12627,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -13041,6 +13101,30 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "demomacro",
     "29217321",
     "FultonG",
-    "odex21"
+    "odex21",
+    "elefevre"
   ],
   "license": "MIT",
   "bugs": {
@@ -163,8 +164,8 @@
     "html-entities": "^2.3.3",
     "html-minifier-terser": "^7.2.0",
     "htmlparser2": "^10.0.0",
-    "image-size": "^2.0.2",
     "jszip": "^3.7.1",
+    "probe-image-size": "^7.2.3",
     "lodash": "^4.17.21",
     "lru-cache": "^10.4.3",
     "mime-types": "^2.1.35",

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -7,7 +7,7 @@
 import { fragment } from 'xmlbuilder2';
 import colorNames from 'color-name';
 import { cloneDeep } from 'lodash';
-import sizeOf from 'image-size';
+import { sync as sizeOf } from 'probe-image-size';
 import { isVNode, isVText } from '../vdom/index';
 import { parseDataUrl, downloadAndCacheImage, buildImage } from '../utils/image';
 

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import mimeTypes from 'mime-types';
-import sizeOf from 'image-size';
+import { sync as sizeOf } from 'probe-image-size';
 
 import { isValidUrl } from './url';
 import * as xmlBuilder from '../helpers/xml-builder';


### PR DESCRIPTION
`image-size` is being flagged by vulnerability scanners such as Snyk:
- Infinite loop on image type ICNS https://security.snyk.io/vuln/SNYK-JS-IMAGESIZE-17295814
- Infinite loop on image types HEIF, JP2, and JXL https://security.snyk.io/vuln/SNYK-JS-IMAGESIZE-17295814

Vulnerabilities are assessed as "High". Practical risk might be lower, as HEIF, JP2, JXL, ICNS are not standard web image formats.

Still, `image-size` is [now archived](https://github.com/image-size/image-size), so it might be appropriate to switch to another library anyway.

Notes:
- made heavy use of Claude Code here; I think the result is good, though
- Claude suggested a few alternative libraries before settling on `probe-image-size`:
    - [image-size@2.x](https://github.com/image-size/image-size) (the existing one); includes the vulnerabilities and is archived
    - [image-size@1.x](https://github.com/image-size/image-size) (the previous version of the same library); this also includes the vulnerability on ICNS
    - [fast-image-size](https://npmx.dev/package/fast-image-size); still in version 0.1.3 and not maintained since 2016
    - [image-meta](https://github.com/unjs/image-meta); still in version 0.2.2; last maintained in Oct 2025; might be vulnerable to ICNS images with zero length too (it's hard to tell)

It seems that `probe-image-size` is a good choice, despite the several dependencies that it is pulling.

Happy to adjust this PR upon your feedback!