### PR TITLE
fix(table): render <tfoot> rows and pin them to the table bottom

### DIFF
--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -3836,6 +3836,10 @@ const buildTable = async (vNode, attributes, docxDocumentInstance) => {
   // multiple grids can cause issue with table rendering
   let isTableGridBuilt = false;
   const rowSpanMap = new Map();
+  // <tfoot> rows are deferred and rendered after all other sections so the
+  // footer always sits at the bottom of the table, regardless of its position
+  // in the source (matching HTML rendering semantics).
+  const tfootVNodes = [];
   if (vNodeHasChildren(vNode)) {
     for (let index = 0; index < vNode.children.length; index++) {
       const childVNode = vNode.children[index];
@@ -3853,7 +3857,7 @@ const buildTable = async (vNode, attributes, docxDocumentInstance) => {
                 modifiedAttributes
               );
               tableFragment.import(tableGridFragment);
-              isTableGridBuilt = false;
+              isTableGridBuilt = true;
             }
             const tableRowFragment = await buildTableRow(
               grandChildVNode,
@@ -3891,6 +3895,9 @@ const buildTable = async (vNode, attributes, docxDocumentInstance) => {
             }
           }
         }
+      } else if (childVNode.tagName === 'tfoot') {
+        // Defer: collected here, rendered after the loop so it lands at the bottom.
+        tfootVNodes.push(childVNode);
       } else if (childVNode.tagName === 'tr') {
         if (index === 0) {
           const tableGridFragment = buildTableGridFromTableRow(childVNode, modifiedAttributes);
@@ -3907,6 +3914,57 @@ const buildTable = async (vNode, attributes, docxDocumentInstance) => {
           tableFragment.import(tableRowFragment);
         }
       }
+    }
+  }
+  // Render deferred <tfoot> rows at the bottom of the table. A footer is a new
+  // row group, so it uses its own rowSpanMap (a rowspan cannot cross a
+  // thead/tbody/tfoot boundary).
+  //
+  // Border position must be computed against the whole rendered table, not the
+  // tfoot's internal index: when the table already has rows (thead/tbody/tr),
+  // a tfoot row is never the table's first row, so only the very last tfoot row
+  // is 'last'. After the F-01 fix `isTableGridBuilt` is true iff such preceding
+  // rows exist, so it doubles as the "has preceding rows" signal here.
+  const tfootRowSpanMap = new Map();
+  const hasPrecedingRows = isTableGridBuilt;
+  const tfootRows = [];
+  for (let tfootIndex = 0; tfootIndex < tfootVNodes.length; tfootIndex++) {
+    const tfootVNode = tfootVNodes[tfootIndex];
+    if (vNodeHasChildren(tfootVNode)) {
+      for (let iteratorIndex = 0; iteratorIndex < tfootVNode.children.length; iteratorIndex++) {
+        const grandChildVNode = tfootVNode.children[iteratorIndex];
+        if (grandChildVNode.tagName === 'tr') {
+          tfootRows.push(grandChildVNode);
+        }
+      }
+    }
+  }
+  for (let rowIndex = 0; rowIndex < tfootRows.length; rowIndex++) {
+    const grandChildVNode = tfootRows[rowIndex];
+    if (!isTableGridBuilt) {
+      const tableGridFragment = buildTableGridFromTableRow(grandChildVNode, modifiedAttributes);
+      tableFragment.import(tableGridFragment);
+      isTableGridBuilt = true;
+    }
+    const isLastTfootRow = rowIndex === tfootRows.length - 1;
+    let rowIndexEquivalent;
+    if (hasPrecedingRows) {
+      // There are preceding rows, so a tfoot row is never the table's first row;
+      // only the very last tfoot row carries the table's bottom border.
+      rowIndexEquivalent = isLastTfootRow ? 'last' : 'middle';
+    } else {
+      // tfoot is the only row group: normal first/last semantics apply.
+      rowIndexEquivalent = setBorderIndexEquivalent(rowIndex, tfootRows.length);
+    }
+    const tableRowFragment = await buildTableRow(
+      grandChildVNode,
+      modifiedAttributes,
+      tfootRowSpanMap,
+      docxDocumentInstance,
+      rowIndexEquivalent
+    );
+    if (tableRowFragment) {
+      tableFragment.import(tableRowFragment);
     }
   }
   tableFragment.up();

--- a/tests/nested-tables.test.js
+++ b/tests/nested-tables.test.js
@@ -872,10 +872,10 @@ describe('Nested Tables - Issue #147', () => {
     });
 
     /**
-     * Pre-existing library limitation: <tfoot> is dropped at all nesting
-     * levels (not specific to nested tables). thead and tbody work.
+     * <thead>, <tbody> and <tfoot> all render, including in nested tables.
+     * (<tfoot> rendering was previously dropped at every nesting level.)
      */
-    test('inner table with thead and tbody renders; tfoot is dropped (pre-existing)', async () => {
+    test('inner table with thead, tbody and tfoot all render', async () => {
       const html = `
         <table border="1">
           <tr>
@@ -893,7 +893,7 @@ describe('Nested Tables - Issue #147', () => {
       expect(Buffer.isBuffer(buf)).toBe(true);
       expect(texts).toContain('headerCol');
       expect(texts).toContain('bodyCol');
-      // footerCol is currently dropped by the library — pin behavior.
+      expect(texts).toContain('footerCol');
     });
 
     test('inner table with caption tag', async () => {

--- a/tests/table-tfoot.test.js
+++ b/tests/table-tfoot.test.js
@@ -1,0 +1,117 @@
+import HTMLtoDOCX from '../index.js';
+import JSZip from 'jszip';
+
+async function getDocumentXml(htmlString) {
+  const buffer = await HTMLtoDOCX(htmlString, null, {});
+  const zip = await JSZip.loadAsync(buffer);
+  return zip.file('word/document.xml').async('string');
+}
+
+// Returns the character index of the first occurrence of `needle` inside the
+// rendered document XML (or -1). Used to assert relative ordering of rows.
+function indexOf(xml, needle) {
+  return xml.indexOf(needle);
+}
+
+describe('Table <tfoot> rendering', () => {
+  test('renders tfoot rows that were previously dropped', async () => {
+    const html = `
+      <table border="1">
+        <thead><tr><th>HEADCELL</th></tr></thead>
+        <tbody><tr><td>BODYCELL</td></tr></tbody>
+        <tfoot><tr><td>FOOTCELL</td></tr></tfoot>
+      </table>
+    `;
+    const doc = await getDocumentXml(html);
+    expect(doc).toContain('FOOTCELL');
+  });
+
+  test('thead + tfoot (no tbody) produces exactly one tblGrid before any row', async () => {
+    const html = `
+      <table border="1">
+        <thead><tr><th>H1</th><th>H2</th></tr></thead>
+        <tfoot><tr><td>F1</td><td>F2</td></tr></tfoot>
+      </table>
+    `;
+    const doc = await getDocumentXml(html);
+    const gridCount = (doc.match(/<w:tblGrid>/g) || []).length;
+    expect(gridCount).toBe(1);
+    // grid must precede every row
+    expect(indexOf(doc, '<w:tblGrid>')).toBeLessThan(indexOf(doc, '<w:tr>'));
+    expect(doc).toContain('F1');
+  });
+
+  test('rowspan in tbody does not bleed into the deferred tfoot row', async () => {
+    // RS declares rowspan=3 but tbody only has 2 rows, so one span is unsatisfied.
+    // A footer is a new row group: the leftover span must NOT continue into tfoot.
+    const html = `
+      <table border="1">
+        <tbody>
+          <tr><td rowspan="3">RS</td><td>b1</td></tr>
+          <tr><td>b2</td></tr>
+        </tbody>
+        <tfoot><tr><td>f1</td></tr></tfoot>
+      </table>
+    `;
+    const doc = await getDocumentXml(html);
+    // Expected vMerge markers: 1 restart (RS) + 1 continue (b2 row). The tfoot
+    // row must add none. Shared rowSpanMap would inject a 3rd into the footer.
+    const vMergeCount = (doc.match(/vMerge/g) || []).length;
+    expect(vMergeCount).toBe(2);
+    expect(doc).toContain('f1');
+  });
+
+  test('single tfoot row after tbody takes the table bottom border, not the top', async () => {
+    // Thick outer border so first/last forcing is visible in cell borders.
+    const html = `
+      <table style="border:6pt solid #000000;border-collapse:collapse;">
+        <tbody><tr><td>b1</td></tr><tr><td>b2</td></tr><tr><td>b3</td></tr></tbody>
+        <tfoot><tr><td>FOOT</td></tr></tfoot>
+      </table>
+    `;
+    const doc = await getDocumentXml(html);
+    const rows = doc.match(/<w:tr>[\s\S]*?<\/w:tr>/g) || [];
+    const footRow = rows.find((r) => /FOOT/.test(r));
+    const topSz = (footRow.match(/<w:top[^/]*w:sz="(\d+)"/) || [])[1] || null;
+    const botSz = (footRow.match(/<w:bottom[^/]*w:sz="(\d+)"/) || [])[1] || null;
+    // tfoot is the bottom of the table: bottom border forced, top NOT forced.
+    expect(topSz).toBeNull();
+    expect(botSz).toBe('48');
+  });
+
+  test('tfoot rendered at the bottom even when it precedes tbody in source', async () => {
+    const html = `
+      <table border="1">
+        <tfoot><tr><td>FOOTROW</td></tr></tfoot>
+        <tbody><tr><td>BODYROW</td></tr></tbody>
+      </table>
+    `;
+    const doc = await getDocumentXml(html);
+    expect(indexOf(doc, 'BODYROW')).toBeLessThan(indexOf(doc, 'FOOTROW'));
+  });
+
+  test('colspan inside tfoot produces a gridSpan', async () => {
+    const html = `
+      <table border="1">
+        <thead><tr><th>A</th><th>B</th></tr></thead>
+        <tbody><tr><td>a1</td><td>b1</td></tr></tbody>
+        <tfoot><tr><td colspan="2">TOTAL</td></tr></tfoot>
+      </table>
+    `;
+    const doc = await getDocumentXml(html);
+    expect(doc).toContain('TOTAL');
+    expect(doc).toMatch(/<w:gridSpan\s+w:val="2"/);
+  });
+
+  test('regression: thead + tbody table emits exactly one tblGrid', async () => {
+    const html = `
+      <table border="1">
+        <thead><tr><th>H1</th><th>H2</th></tr></thead>
+        <tbody><tr><td>a</td><td>b</td></tr></tbody>
+      </table>
+    `;
+    const doc = await getDocumentXml(html);
+    const gridCount = (doc.match(/<w:tblGrid>/g) || []).length;
+    expect(gridCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

`<tfoot>` sections were silently dropped during conversion. `buildTable` only handled `colgroup`, `thead`, `tbody`, and direct `tr` children — there was no `tfoot` branch, so footer rows (totals, summaries) never appeared in the generated document.

## Fix

Collect `<tfoot>` during the child loop and render it **after** all other sections, so the footer always lands at the bottom of the table regardless of its position in the source (matching HTML rendering semantics).

Three coupled correctness issues surfaced while wiring this up and are fixed in the same change:

1. **Duplicate table grid** — the `thead` branch built the `<w:tblGrid>` but left `isTableGridBuilt = false`, so a following section could emit a second grid. This also fixes a pre-existing `thead`+`tbody` double-grid case.
2. **Rowspan bleed** — footer rows now use a dedicated `rowSpanMap`. An unsatisfied `rowspan` in `tbody` can no longer continue into the first `tfoot` row (rowspans don't cross row-group boundaries in HTML).
3. **Border position** — a `tfoot` row's first/last border position is computed against the whole rendered table, so the footer is never treated as the table's first row (previously it received the table's top border and, for a single-row footer, lost the bottom border).

## Tests

- New `tests/table-tfoot.test.js`: tfoot rendering, bottom placement when `tfoot` precedes `tbody` in source, single `tblGrid` for `thead`+`tfoot`, rowspan non-bleed, footer border, `colspan`→`gridSpan`, and a `thead`+`tbody` regression.
- Updated the `nested-tables` test that previously pinned the drop-behavior.
- Full suite: **625 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)