### PR TITLE
chore(security): close runtime Dependabot advisories (form-data, postcss)

### DIFF
--- a/example/nextjs-example/package-lock.json
+++ b/example/nextjs-example/package-lock.json
@@ -22,7 +22,7 @@
     },
     "../..": {
       "name": "@turbodocx/html-to-docx",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -919,9 +919,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -938,9 +938,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/example/nextjs-example/package.json
+++ b/example/nextjs-example/package.json
@@ -19,5 +19,8 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "typescript": "^5.6.0"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7127,16 +7127,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -7675,9 +7675,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
   "overrides": {
     "bl": "^1.2.3",
     "semver": "^7.6.0",
+    "form-data": "^4.0.6",
     "sharp": {
       "semver": "^7.6.0"
     }


### PR DESCRIPTION
## Summary

Closes the **2 runtime Dependabot advisories** in `@turbodocx/html-to-docx` — the set that matters for a published package and its example. Opened by **Claude Code** on behalf of @amitsharma-turbodocx.

Closes #213

## Changes

| # | Package | Sev | Before → After | Where |
|---|---|---|---|---|
| #270 | `form-data` | high | 4.0.5 → 4.0.6 | root `overrides` (`^4.0.6`) |
| #269 | `postcss` | medium | 8.4.31 → 8.5.19 | `example/nextjs-example` scoped override (`^8.5.10`) |

- **form-data** `GHSA-hmw2-7cc7-3qxx` (CRLF injection) — transitive in the library tree.
- **postcss** (`<8.5.10`) — transitive under `next ^16` in the example app's own lockfile (Dependabot scans it separately).

**Left for the next tranche:** `js-yaml` ×2 and `@babel/core` — all dev-scope, don't ship to consumers.

## Risk / rollback
- Both are **same-major** bumps (form-data 4.x, postcss 8.x) the existing ranges already permit — no ERESOLVE. Neither is imported directly by `src/` (transitive infra libs), so version-only, no API impact.
- Gate: CI `npm ci` + `npm run test:all`.
- Rollback: revert the merge commit and republish.

## Verification
- Per-advisory range check: both targeted advisories resolve in the regenerated lockfiles (form-data 4.0.6, postcss 8.5.19).
- Fresh-context review (separate agent): lockfile sync + no major-boundary crossing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
