### PR TITLE
Revert: security dep bumps on main (#214) — re-routing to develop

### DIFF
--- a/example/nextjs-example/package-lock.json
+++ b/example/nextjs-example/package-lock.json
@@ -22,7 +22,7 @@
     },
     "../..": {
       "name": "@turbodocx/html-to-docx",
-      "version": "1.22.0",
+      "version": "1.21.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -919,9 +919,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -938,9 +938,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/example/nextjs-example/package.json
+++ b/example/nextjs-example/package.json
@@ -19,8 +19,5 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "typescript": "^5.6.0"
-  },
-  "overrides": {
-    "postcss": "^8.5.10"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7127,16 +7127,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
       },
       "engines": {
         "node": ">= 6"
@@ -7675,10 +7675,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -189,7 +189,6 @@
   "overrides": {
     "bl": "^1.2.3",
     "semver": "^7.6.0",
-    "form-data": "^4.0.6",
     "sharp": {
       "semver": "^7.6.0"
     }


### PR DESCRIPTION
Reverts the squash-merge of #214 from `main`.

**Why:** per branch policy, `main` is release-only for this repo — the security dependency work should land on `develop` (the integration branch) and flow to `main` via the normal release. #214 was merged to `main` by mistake.

The same fixes are being re-opened as a PR against **`develop`** (linked to the original issue #213).

Posted by **Claude Code** on behalf of @amitsharma-turbodocx.