### PR TITLE
fix(options): treat null document options as defaults

### DIFF
--- a/src/utils/options-utils.js
+++ b/src/utils/options-utils.js
@@ -62,22 +62,24 @@ const normalizeUnits = (dimensioningObject, defaultDimensionsProperty) => {
  */
 
 const createDocumentOptionsAndMergeWithDefaults = (documentOptions) => {
+  const userDocumentOptions = documentOptions ?? {};
+
   // Start with a shallow copy of the user-provided options to avoid mutating the original object
-  const normalizedDocumentOptions = { ...documentOptions };
+  const normalizedDocumentOptions = { ...userDocumentOptions };
 
   // Iterate over each key in the user-provided options
-  Object.keys(documentOptions).forEach((key) => {
+  Object.keys(userDocumentOptions).forEach((key) => {
     switch (key) {
       case 'pageSize':
       case 'margins':
         normalizedDocumentOptions[key] = normalizeUnits(
-          documentOptions[key],
+          userDocumentOptions[key],
           defaultDocumentOptions[key]
         );
         break;
       case 'fontSize':
       case 'complexScriptFontSize':
-        normalizedDocumentOptions[key] = fixupFontSize(documentOptions[key]);
+        normalizedDocumentOptions[key] = fixupFontSize(userDocumentOptions[key]);
         break;
       // If there are other keys that require normalization, handle them here
       default:

--- a/tests/document-options.test.js
+++ b/tests/document-options.test.js
@@ -1,0 +1,11 @@
+import HTMLtoDOCX from '../index.js';
+import { parseDOCX } from './helpers/docx-assertions.js';
+
+describe('Document options', () => {
+  test('treats null document options as defaults', async () => {
+    const docx = await HTMLtoDOCX('<p>Hello from defaults</p>', null, null);
+    const parsed = await parseDOCX(docx);
+
+    expect(parsed.paragraphs.map((paragraph) => paragraph.text)).toContain('Hello from defaults');
+  });
+});


### PR DESCRIPTION
## Summary

- normalize explicit `null` document options to an empty options object
- preserve existing unit normalization and default-option merging behavior
- add a public-API regression test that generates and parses a DOCX with `HTMLtoDOCX(html, null, null)`

## Problem

JavaScript default parameters handle omitted and `undefined` values, but not an explicit `null`. `null` therefore reached `Object.keys(documentOptions)` and threw `TypeError: Cannot convert undefined or null to object` before document generation.

Using nullish normalization at the options boundary makes `null` behave like omitted options without changing valid falsy option values nested inside an options object.

## Verification

- regression test reproduced the `Object.keys(null)` failure before the implementation
- `npm run test:all` (636 Jest tests plus standard, heading, TypeScript, and RTL example builds)
- `npx prettier --check src/utils/options-utils.js tests/document-options.test.js`
- `npx eslint src/utils/options-utils.js`
- `git diff --check`

## CI dependency

The current `docx-diff` failure is the base-workflow defect fixed by #233: the job checks out `develop` for both baseline and current, then rejects `../diff-report.md` as outside its working directory. This PR needs that base workflow fix to land and the check to be rerun.

Closes #133