### PR TITLE
ci: write the docx diff report inside the working directory

### DIFF
--- a/.github/workflows/docx-diff.yml
+++ b/.github/workflows/docx-diff.yml
@@ -77,15 +77,15 @@ jobs:
         id: diff
         working-directory: current
         run: |
-          node scripts/diff-docx.js ../baseline.docx ../current.docx --output ../diff-report.md || echo "diff_failed=true" >> $GITHUB_OUTPUT
+          node scripts/diff-docx.js ../baseline.docx ../current.docx --output diff-report.md || echo "diff_failed=true" >> $GITHUB_OUTPUT
 
       - name: Read TurboDocx diff report
         id: report
         run: |
-          if [ -f diff-report.md ]; then
+          if [ -f current/diff-report.md ]; then
             {
               echo 'report<<EOF'
-              cat diff-report.md
+              cat current/diff-report.md
               echo EOF
             } >> $GITHUB_OUTPUT
           fi
@@ -96,7 +96,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync('diff-report.md', 'utf8');
+            const report = fs.readFileSync('current/diff-report.md', 'utf8');
 
             // Find existing comment
             const comments = await github.rest.issues.listComments({
@@ -138,7 +138,7 @@ jobs:
           path: |
             baseline.docx
             current.docx
-            diff-report.md
+            current/diff-report.md
           retention-days: 30
 
       - name: Verify DOCX regression test results


### PR DESCRIPTION
Opening this separately as @nicolasiscoding suggested on #229, so the workflow fix is reviewable on its own and #229 can rebase onto it.

## The problem

`docx-diff` currently fails on **every** PR in the repo, for a reason unrelated to DOCX output.

[#225](https://github.com/TurboDocx/html-to-docx/pull/225) added a path guard to `scripts/diff-docx.js`:

```js
if (outputPath && !outputPath.startsWith(process.cwd() + path.sep)) {
  console.error("Output path must be within the current working directory");
  process.exit(1);
}
```

`.github/workflows/docx-diff.yml` still invokes the script as:

```yaml
working-directory: current
run: node scripts/diff-docx.js ../baseline.docx ../current.docx --output ../diff-report.md
```

`process.cwd()` is `current/`, so `../diff-report.md` resolves outside it, the guard fires, and the script exits 1 **before comparing anything**. The workflow records that as `diff_failed=true`, and the verify step then reports:

> DOCX diff detected unexpected changes. Please review the diff report.

which is misleading — no comparison ran.

## The fix

Write the report to `diff-report.md` inside `current/`, which satisfies the guard, and point the three consumers at `current/diff-report.md`:

| Step | Before | After |
|---|---|---|
| Run diff analysis | `--output ../diff-report.md` | `--output diff-report.md` |
| Read diff report | `diff-report.md` | `current/diff-report.md` |
| Post PR comment | `diff-report.md` | `current/diff-report.md` |
| Upload artifact | `diff-report.md` | `current/diff-report.md` |

**The guard in `scripts/diff-docx.js` is untouched** — this only changes where the workflow asks for the report.

## Verification

- Running the script with an in-tree output path completes normally: **71 identical files, 0 changed, 0 new, 0 deleted**.
- Every `docx-diff` run before 2026-08-23 succeeded; the failures start with the guard landing.
- `bugfix/dependabot-security-patches-2026-08` failed the same check three times on 2026-08-24, on a branch that touches no rendering code.

## One thing worth noting separately

`|| echo "diff_failed=true"` treats *any* non-zero exit as a detected regression, but `diff-docx.js` exits 1 both for a real finding (`unexpected deletions detected`) and for setup failures like this one. That conflation is what made this bug present as a rendering regression. Happy to separate those in a follow-up if useful — left out here to keep this reviewable.